### PR TITLE
Solved encoding bug

### DIFF
--- a/plasTeX/Base/LaTeX/Index.py
+++ b/plasTeX/Base/LaTeX/Index.py
@@ -7,7 +7,7 @@ C.11.5 Index and Glossary (p211)
 
 import string, os
 from plasTeX.Tokenizer import Token, EscapeSequence
-from plasTeX import Command, Environment
+from plasTeX import Command, Environment, encoding
 from plasTeX.Logging import getLogger
 from Sectioning import SectionUtils
 
@@ -69,7 +69,7 @@ class IndexUtils(object):
         for item in self:
             try: 
                 label = title = item.sortkey[0].upper()
-                if title in string.letters:
+                if title in encoding.stringletters():
                     pass
                 elif title == '_':
                      title = '_ (Underscore)'

--- a/plasTeX/Renderers/ManPage/__init__.py
+++ b/plasTeX/Renderers/ManPage/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from plasTeX.Renderers import Renderer as BaseRenderer
+from plasTeX import encoding
 import textwrap, re, string
 
 class ManPageRenderer(BaseRenderer):
@@ -43,7 +44,7 @@ class ManPageRenderer(BaseRenderer):
     def default(self, node):
         """ Rendering method for all non-text nodes """
         # Handle characters like \&, \$, \%, etc.
-        if len(node.nodeName) == 1 and node.nodeName not in string.letters:
+        if len(node.nodeName) == 1 and node.nodeName not in encoding.stringletters():
             return self.textDefault(node.nodeName)
             
         # Render child nodes

--- a/plasTeX/Renderers/Text/__init__.py
+++ b/plasTeX/Renderers/Text/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from plasTeX.Renderers import Renderer as BaseRenderer
+from plasTeX import encoding
 import textwrap, re, string
 
 class TextRenderer(BaseRenderer):
@@ -50,7 +51,7 @@ class TextRenderer(BaseRenderer):
     def default(self, node):
         """ Rendering method for all non-text nodes """
         # Handle characters like \&, \$, \%, etc.
-        if len(node.nodeName) == 1 and node.nodeName not in string.letters:
+        if len(node.nodeName) == 1 and node.nodeName not in encoding.stringletters():
             return self.textDefault(node.nodeName)
             
         # Render child nodes

--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -2,6 +2,7 @@
 
 import string
 from DOM import Node, Text
+from plasTeX import encoding
 from StringIO import StringIO as UnicodeStringIO
 try: from cStringIO import StringIO
 except: from StringIO import StringIO
@@ -19,7 +20,7 @@ DEFAULT_CATEGORIES = [
    '_',   # 8  - Subscript
    '\x00',# 9  - Ignored character
    ' \t\r\f', # 10 - Space
-   string.letters + '@', # - Letter
+   encoding.stringletters() + '@', # - Letter
    '',    # 12 - Other character - This isn't explicitly defined.  If it
           #                        isn't any of the other categories, then
           #                        it's an "other" character.
@@ -29,7 +30,7 @@ DEFAULT_CATEGORIES = [
 ]
 
 VERBATIM_CATEGORIES = [''] * 16
-VERBATIM_CATEGORIES[11] = string.letters
+VERBATIM_CATEGORIES[11] = encoding.stringletters()
 
 class Token(Text):
     """ Base class for all TeX tokens """
@@ -441,7 +442,7 @@ class Tokenizer(object):
 # HACK: I couldn't get the parse() thing to work so I'm just not
 #       going to parse whitespace after EscapeSequences that end in
 #       non-letter characters as a half-assed solution.
-                        if token[-1] in string.letters:
+                        if token[-1] in encoding.stringletters():
                             # Absorb following whitespace
                             self.state = STATE_S
 

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -5,7 +5,7 @@ __version__ = '9.3'
 import string, re
 from DOM import Element, Text, Node, DocumentFragment, Document
 from Tokenizer import Token, BeginGroup, EndGroup, Other
-from plasTeX import Logging
+from plasTeX import Logging, encoding
 
 log = Logging.getLogger()
 status = Logging.getLogger('status')
@@ -429,7 +429,7 @@ class Macro(Element):
         argSource = sourceArguments(self)
         if not argSource:
             argSource = ' '
-        elif argSource[0] in string.letters:
+        elif argSource[0] in encoding.stringletters():
             argSource = ' %s' % argSource
         s = '%s%s%s' % (escape, name, argSource)
 
@@ -633,7 +633,7 @@ class Macro(Element):
                 pass
 
             # Argument name (and possibly type)
-            elif item[0] in string.letters:
+            elif item[0] in encoding.stringletters():
                 parts = item.split(':')
                 item = parts.pop(0)
                 # Parse for types and subtypes
@@ -1139,11 +1139,11 @@ class dimen(float):
     def __new__(cls, v):
         if isinstance(v, Macro):
             return v.__dimen__()
-        elif isinstance(v, basestring) and v[-1] in string.letters:
+        elif isinstance(v, basestring) and v[-1] in encoding.stringletters():
             # Get rid of glue components
             v = list(v.split('plus').pop(0).split('minus').pop(0).strip())
             units = []
-            while v and v[-1] in string.letters:
+            while v and v[-1] in encoding.stringletters():
                 units.insert(0, v.pop())
             v = float(''.join(v))
             units = ''.join(units) 
@@ -1503,7 +1503,7 @@ class Counter(object):
 
     @property
     def Alph(self):
-        return string.letters[self.value-1].upper()
+        return encoding.stringletters()[self.value-1].upper()
 
     @property
     def alph(self):

--- a/plasTeX/encoding.py
+++ b/plasTeX/encoding.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import locale
+import string
+
+def stringletters():
+    encoding = locale.getlocale()[1]
+    if encoding:
+        return unicode(string.letters, encoding)
+    else:
+        return unicode(string.letters)

--- a/unittests/Encoding.py
+++ b/unittests/Encoding.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import locale
+import unittest
+from plasTeX.TeX import TeX
+
+class Longtables(unittest.TestCase):
+
+    def runDocument(self, content):
+        """
+        Compile a document with the given content
+
+        Arguments:
+        content - string containing the content of the document
+
+        Returns: TeX document
+
+        """
+        tex = TeX()
+        tex.disableLogging()
+        tex.input(ur'''\document{article}\begin{document}%s\end{document}''' % content)
+        return tex.parse()
+
+    def testString(self):
+        # Bad character encoding
+        locale.setlocale(locale.LC_ALL, "en_GB.iso8859-1")
+        out = self.runDocument(u"é")
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
At several places in plasTeX, the string `string.letters` is used. It works well when manipulating English strings, but in a French environment, as the `string.letters` [depends on the current locale](https://docs.python.org/2/library/string.html#string.letters), it contains characters with accents (like `é`), and encoding matters, and we get the usual:

``` python
  [...]
  File "/usr/lib/pymodules/python2.7/plasTeX/TeX.py", line 387, in parse
    for item in tokens:
  File "/usr/lib/pymodules/python2.7/plasTeX/TeX.py", line 46, in next
    return self._next()
  File "/usr/lib/pymodules/python2.7/plasTeX/TeX.py", line 275, in __iter__
    token = next()
  File "/usr/lib/pymodules/python2.7/plasTeX/TeX.py", line 244, in itertokens
    t = inputs[-1][-1].next()
  File "/usr/lib/pymodules/python2.7/plasTeX/Tokenizer.py", line 440, in __iter__
    if token[-1] in string.letters:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xaa in position 52: ordinal not in range(128)
```

This patch solves this. A unittest is given, that fails without the patch, and succeed with it.

The principle of this patch is: instead of using directly `string.letters`, we convert it to unicode using the encoding of the current locale if it is set.

By the way: is there any plan to publish a new version? The last one (0.9.3) is [five years old](https://github.com/tiarno/plastex/commit/0e8f235cd04fcc807a841754e0fe416681612815), and the versions that can be installed using pip or GNU/Linux distributions are very old : [pip](https://pypi.python.org/pypi/plasTeX), [debian](https://packages.debian.org/source/squeeze/plastex), [opensuse](http://software.opensuse.org/package/plasTeX?search_term=plastex)…
