### PR TITLE
single line breaks in listings package

### DIFF
--- a/plasTeX/Packages/listings.py
+++ b/plasTeX/Packages/listings.py
@@ -94,7 +94,11 @@ def _format(self, file):
             line = re.sub('/\*@[^@]*@\*/', '', line)
 
             # Add the just-read line to the listing.
-            self.plain_listing += line
+            if hasattr(file, 'read'):
+                self.plain_listing += line
+            else:
+                self.plain_listing += '\n' + line
+
 
     # Create a syntax highlighted XHTML version of the file using Pygments
     if pygments is not None:

--- a/plasTeX/Packages/listings.py
+++ b/plasTeX/Packages/listings.py
@@ -94,7 +94,7 @@ def _format(self, file):
             line = re.sub('/\*@[^@]*@\*/', '', line)
 
             # Add the just-read line to the listing.
-            self.plain_listing += '\n' + line
+            self.plain_listing += line
 
     # Create a syntax highlighted XHTML version of the file using Pygments
     if pygments is not None:


### PR DESCRIPTION
This replaces double line breaks with single ones in the member variable `plain_listing` in classes from `Packages/listings.py`.

Explanation: When iterating over the lines of a file, the newline characters are not stripped from the iterated variable.  So, appending a newline doubles the line breaks.