### PR TITLE
support \endverbatim

### DIFF
--- a/plasTeX/Base/LaTeX/Verbatim.py
+++ b/plasTeX/Base/LaTeX/Verbatim.py
@@ -59,7 +59,7 @@ class verbatim(Environment):
                         res = [end]
                     tex.pushTokens(res)
                     break
-            elif len(tokens) >= endlength2:
+            if len(tokens) >= endlength2:
                 if tokens[-endlength2:] == endpattern2:
                     tokens = tokens[:-endlength2]
                     self.ownerDocument.context.pop(self)


### PR DESCRIPTION
The `elif` would prevent `\endverbatim` to be matched, leaving only `\end{verbatim}` working.
This fixes the problem.

However, **a problem remains** when `\endverbatim` is part of a file included with `\include{...}`.

For example, if `foo.tex` contains
```latex
\verbatim
Foo 2
Bar 2
\endverbatim
\begin{verbatim}
Foo 3
Bar 3
\end{verbatim}
```
the following
```latex
    \documentclass{article}
    \begin{document}
    \include{foo}
    \end{document}
```
plasTeX incorrectly matches
```
Foo 2
Bar 2
\endverbatim
\begin{verbatim}
Foo 3
Bar 3
```
as the content of a single verbatim environment, whereas plasTeX correctly matches two distinct verbatim environments in the following:
```latex
\documentclass{article}
\begin{document}
\verbatim
Foo 2
Bar 2
\endverbatim
\begin{verbatim}
Foo 3
Bar 3
\end{verbatim}
\end{document}
```

Any ideas?