### PR TITLE
support nested maths in MathShift

### DIFF
--- a/plasTeX/Base/TeX/Primitives.py
+++ b/plasTeX/Base/TeX/Primitives.py
@@ -76,32 +76,23 @@ class MathShift(Command):
 
         """
         inEnv = type(self).inEnv
-        math = self.ownerDocument.createElement('math')
-        displaymath = self.ownerDocument.createElement('displaymath')
 
-        # See if this is the end of the environment
-        if inEnv and inEnv[-1] is not None:
-            env = inEnv.pop()
-            if type(env) is type(displaymath):
-                for t in tex.itertokens():
-                    break
-                displaymath.macroMode = Command.MODE_END
-                self.ownerDocument.context.pop(displaymath)
-                return [displaymath]
-            else:
-                math.macroMode = Command.MODE_END
-                self.ownerDocument.context.pop(math)
-                return [math]
-
+        current = self.ownerDocument.createElement('math')
         for t in tex.itertokens():
             if t.catcode == Token.CC_MATHSHIFT:
-                inEnv.append(displaymath)
+                current = self.ownerDocument.createElement('displaymath')
             else:
-                inEnv.append(math)
                 tex.pushToken(t)
             break
 
-        current = inEnv[-1]
+        # See if this is the end of the environment
+        if inEnv and inEnv[-1] is not None and type(inEnv[-1]) is type(current):
+            inEnv.pop()
+            current.macroMode = Command.MODE_END
+            self.ownerDocument.context.pop(current)
+            return [current]
+
+        inEnv.append(current)
         mathshiftlog.debug('%s (%s)' % (current.tagName, id(current)))
         self.ownerDocument.context.push(current)
 


### PR DESCRIPTION
This is useful when using commands that turn off math mode, such as the old `\cases` macro or AMS's `\text`.

The old implementation would consider the current MathShift command as a closing one whenever there already was an open math environment.  This led to a bug in
`$$ x = \text{$x$} $$`
as well as in
`$$ x = \cases{x & if $x=x$} $$`

The new implementation regards the current MathShift command as a closing command *only if it matches the last opening command*.  This should not break the parsing of correct LaTeX code.

Successfully passed a regression test on a project of 477 LaTeX files.