### PR TITLE
Adds Jinja2 support

### DIFF
--- a/Doc/renderers.tex
+++ b/Doc/renderers.tex
@@ -485,7 +485,8 @@ raise an \exception{AttributeError} exception.
 
 The Page Template (PT) renderer is a renderer for \plasTeX\ document
 objects that supports various page template engines such as 
-\href{http://www.zope.org/Documentation/Books/ZopeBook/2_6Edition/ZPT.stx}{Zope Page Templates (ZPT)}, 
+\href{http://www.zope.org/Documentation/Books/ZopeBook/2_6Edition/ZPT.stx}{Zope
+Page Templates (ZPT)}, \href{http://jinja.pocoo.org/}{Jinja2 templates},
 \href{http://www.cheetahtemplate.org/}{Cheetah templates}, 
 \href{http://kid-templating.org/}{Kid templates}, 
 \href{http://genshi.edgewall.org/}{Genshi templates}, 
@@ -551,6 +552,7 @@ names in the document object.
 The extensions used for all templating engines are shown in the table below.
 \begin{tableiii}{l|l|l}{}{Engine}{Extension}{Output Type}
 \lineiii{ZPT}{.html, .htm, .zpt}{HTML}
+\lineiii{Jinja2}{.jinja2}{Any}
 \lineiii{}{.xhtml, .xhtm, .xml}{XML/XHTML}
 \lineiii{Python string formatting}{.pyt}{Any}
 \lineiii{Python string templates}{.st}{Any}
@@ -573,7 +575,8 @@ textit.html
 Since there are a lot of templates that are merely one line, it would be
 inconvenient to have to create a new file for each template.  In cases
 like this, you can use the \file{.zpts} extension for collections of
-ZPT templates, or more generally \file{.pts} for collections of various 
+ZPT templates, or the \file{.jinja2s} extension for collections of
+Jinja2 templates, or more generally \file{.pts} for collections of various 
 template types.  Files with this
 extension have multiple templates in them.  Each template is separated
 from the next by the template metadata which includes things like the 
@@ -583,8 +586,8 @@ metadata names are currently supported.
 \begin{tableii}{l|p{4in}}{}{Name}{Purpose}
 \lineii{engine}{the name of the templating engine to use.  At the time of
     this writing, the value could be zpt, tal (same as zpt), 
-    html (ZPT HTML template), xml (ZPT XML template), python
-    (Python formatted string), string (Python string template),
+    html (ZPT HTML template), xml (ZPT XML template), jinja2,
+		python (Python formatted string), string (Python string template),
     kid, cheetah, or genshi.}
 \lineii{name}{the name or names of the template that is to follow. 
     This name is used as the key in the renderer, and also 
@@ -650,26 +653,33 @@ template.  By default, templates in a zpts file use the HTML compiler
 in SimpleTAL.  You can specify that a template is an XML template by using
 the type directive.
 
-Here is an example of using various types of templates in a single file.
+Here is an example of using various templates engines in a single file.
 \begin{verbatim}
+name: equation
+engine: jinja2
+<div class="equation" id="{{ obj.id }}">
+  <span class="equation_label">{{ obj.ref }}</span>
+  {{ obj }}
+</div>
+
 name: textbf
-type: python
+engine: python
 <b>%(self)s</b>
 
 name: textit
-type: string
+engine: string
 <i>${self}</i>
 
 name: textsc
-type: cheetah
+engine: cheetah
 <span class="textsc">${here}</span>
 
 name: textrm
-type: kid
+engine: kid
 <span class="textrm" py:content="XML(unicode(here))">normal text</span>
 
 name: textup
-type: genshi
+engine: genshi
 <span class="textup" py:content="markup(here)">upcase text</span>
 \end{verbatim}
 
@@ -678,13 +688,14 @@ a list of the variables and the templates that support them.
 
 \begin{center}
 \begin{tabular}{|l|l|l|l|}\hline
-\textbf{Object} & \textbf{ZPT/Python Formats/String Template} & 
+\textbf{Object} & \textbf{ZPT/Python Formats/String Template} &
+\textbf{Jinja2} &
     \textbf{Cheetah} & \textbf{Kid/Genshi}\\\hline
-document node & \var{self} or \var{here} & \var{here} & \var{here} \\
-parent node & \var{container} & \var{container} & \var{container} \\
-document config & \var{config} & \var{config} & \var{config} \\
-template instance & \var{template} &  & \\
-renderer instance & \var{templates} & \var{templates} & \var{templates} \\\hline
+document node & \var{self} or \var{here} & \var{obj} or \var{here} &  \var{here} & \var{here} \\
+parent node & \var{container} & \var{container} & \var{container} & \var{container} \\
+document config & \var{config} & \var{config} & \var{config} & \var{config} \\
+template instance & \var{template} &  & & \\
+renderer instance & \var{templates} & \var{templates} & \var{templates} & \var{templates} \\\hline
 \end{tabular}
 \end{center}
 

--- a/plasTeX/Renderers/PageTemplate/__init__.py
+++ b/plasTeX/Renderers/PageTemplate/__init__.py
@@ -17,6 +17,28 @@ from plasTeX.Renderers.PageTemplate.simpletal.simpleTALUtils import FastStringOu
 
 log = plasTeX.Logging.getLogger()
 
+# Support for Jinja2 templates
+try: 
+
+    from jinja2 import Template as Jinja2Template
+    def jinja2template(s, encoding='utf8'):
+        def renderjinja2(obj, s=s):
+            tvars = {'here':obj, 
+                     'obj':obj,
+                     'container':obj.parentNode,
+                     'config':obj.ownerDocument.config,
+                     'context':obj.ownerDocument.context,
+                     'templates':obj.renderer}
+            return Jinja2Template(s).render(tvars) 
+        return renderjinja2
+
+except ImportError:
+
+    def jinja2template(s, encoding='utf8'):
+        def renderjinja2(obj):
+            return unicode(s, encoding)
+        return renderjinja2
+
 # Support for Python string templates
 def stringtemplate(s, encoding='utf8'):
     template = string.Template(unicode(s, encoding))
@@ -254,6 +276,7 @@ class PageTemplate(BaseRenderer):
         self.registerEngine('genshi', None, '.gen', genshihtmltemplate)
         self.registerEngine('genshi', 'xml', '.genx', genshixmltemplate)
         self.registerEngine('genshi', 'text', '.gent', genshitexttemplate)
+        self.registerEngine('jinja2', None, '.jinja2', jinja2template)
 
     def registerEngine(self, name, type, ext, function):
         """


### PR DESCRIPTION
This PR is related to Issue #25. It adds support for the popular [jinja2 template engine](http://jinja.pocoo.org/) (if available).

This template engine will be familiar to anyone having worked with [Django](https://github.com/django/django), either directly using Jinja or Django's native template engine which inspired Jinja.

The chosen file extension is ``.jinja2`` (I don't think there is any established convention here, jinja templates are always ``.html`` when I see them, but could produce any kind of text document).

I tried to update the documentation as well but I must confess I wasn't able to compile the documentation (even before my changes) and I modified something which seemed wrong to me (confusion between parameters ``type`` and ``engine`` for a template but I don't really understand what is ``type``).