### PR TITLE
Filter exception more wisely for package debugging

### DIFF
--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -408,7 +408,7 @@ class Context(object):
 
         except ImportError, msg:
             # No Python module
-            if 'No module' in str(msg):
+            if 'No module' in str(msg) and module in str(msg):
                 pass
                 # Failed to load Python package
 #               log.warning('No Python version of %s was found' % file)


### PR DESCRIPTION
A common python pitfall is to use exception as a flow control mechanism, but intercept too much.

Let's take a real life example. I create a plasTeX package ``mypackage.py`` which starts with
```python
from plastex import Command

...
```

Then my TeX document contains ``\usepackage{mypackage}`` and I get the error message ``Could not find any file named: mypackage.sty``. Why isn't plastex using ``mypackage.py``?!

After a couple of hours of confusion and debugging comes the answer. There is a typo in the import statement which should read ``from plasTeX import Command``.  Hence an ``ImportError`` exception is raised. But plasTeX incorrectly assumes that trying to import ``mypackage.py`` raised the exception and starts looking for another implementation (INI or LaTeX).

This PR proposes a slightly more careful way to handle this. It's certainly not foolproof but enough to handle the situation described above.