### PR TITLE
Allow renderers to define config options

### DIFF
--- a/plasTeX/plastex
+++ b/plasTeX/plastex
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os, sys, codecs, string, glob
+import importlib
 import plasTeX
 from plasTeX.TeX import TeX
 from plasTeX.Config import config
@@ -11,9 +12,23 @@ log = getLogger()
 
 __version__ = '1.0'
 
+def collect_renderer_config(config):
+    plastex_dir = os.path.dirname(os.path.realpath(__file__))
+    renderers_dir = os.path.join(plastex_dir, 'Renderers')
+    renderers = next(os.walk(renderers_dir))[1]
+    for renderer in renderers:
+        try:
+            conf = importlib.import_module('plasTeX.Renderers.'+renderer+'.Config')
+        except ImportError, msg:
+            continue
+
+        config += conf.config
+
 def main(argv):
     """ Main program routine """
     print >>sys.stderr, 'plasTeX version %s' % __version__
+
+    collect_renderer_config(config)
 
     # Parse the command line options
     try:


### PR DESCRIPTION
This PR tackles issue #31 (which is maybe what is referred to in the TODO file: "Renderer specific config files"). 

The goal is to allow renderers to define options (either command line or config files). 

### Interface

Each renderer directory can contain a ``Config.py`` file which defines a variable ``config`` which is a ``ConfigManager`` instance. For instance, one can add a file ``plasTeX/Renderer/XHTML/Config.py`` containing:
```python
from plasTeX.ConfigManager import *

config = ConfigManager()

section = config.add_section('xhtml')

config.add_category('xhtml', 'XHTML renderer Options')

section['test'] = StringOption(
    """ Test option """,
    options='--test',
    category='xhtml',
    default='Yop',
)
```

When the main ``plastex`` script is invoked, it will add the ``test`` option to the recognized options, and its value will be available when rendering.

### Implementation

Everything happens inside the main script, we simply try to import a ``Config`` submodule from each renderer and merge it using the ability of ``ConfigManager`` objects to be merged (using ``__iadd__``).

### Backward compatibility

This PR is fully backward compatible, renderers are free not to implement a ``Config`` submodule.