### PR TITLE
Add textsuperscript template for XHTML renderer

### DIFF
--- a/plasTeX/Renderers/XHTML/Sentences.zpts
+++ b/plasTeX/Renderers/XHTML/Sentences.zpts
@@ -48,3 +48,6 @@ comment: &#8201;
 
 name: underbar
 <span class="underbar" tal:content="self">underbar</span>
+
+name: textsuperscript
+<sup tal:content="self">superscripted text</sup>


### PR DESCRIPTION
This is a tiny PR adding a template for textsuperscript in XHTML (translated into a sup tag). See the discussion in #39.