### PR TITLE
Fix pdf documentation generation

### DIFF
--- a/Doc/plastex.tex
+++ b/Doc/plastex.tex
@@ -2,6 +2,7 @@
 
 \usepackage[T1]{fontenc}
 \usepackage{graphicx}
+\usepackage{makeidx}
 \usepackage{hyperref}
 
 \newcommand{\titleref}{\ref}
@@ -69,6 +70,6 @@
 
 \input{parsing-faq}
 
-\input{plastex.ind}
+\printindex
 
 \end{document}

--- a/Doc/renderers.tex
+++ b/Doc/renderers.tex
@@ -600,8 +600,8 @@ names in the document object.
 The extensions used for all templating engines are shown in the table below.
 \begin{tableiii}{l|l|l}{}{Engine}{Extension}{Output Type}
 \lineiii{ZPT}{.html, .htm, .zpt}{HTML}
-\lineiii{Jinja2}{.jinja2}{Any}
 \lineiii{}{.xhtml, .xhtm, .xml}{XML/XHTML}
+\lineiii{Jinja2}{.jinja2}{Any}
 \lineiii{Python string formatting}{.pyt}{Any}
 \lineiii{Python string templates}{.st}{Any}
 \lineiii{Kid}{.kid}{XML/XHTML}
@@ -735,7 +735,7 @@ There are several variables inserted into the template namespace.  Here is
 a list of the variables and the templates that support them.
 
 \begin{center}
-\begin{tabular}{|l|l|l|l|}\hline
+\begin{tabular}{|l|l|l|l|l|}\hline
 \textbf{Object} & \textbf{ZPT/Python Formats/String Template} &
 \textbf{Jinja2} &
     \textbf{Cheetah} & \textbf{Kid/Genshi}\\\hline

--- a/Doc/texinputs/python.sty
+++ b/Doc/texinputs/python.sty
@@ -7,6 +7,7 @@
              [1998/01/11 LaTeX package (Python markup)]
 
 \RequirePackage{longtable}
+\RequirePackage{ifpdf}
 
 % Uncomment these two lines to ignore the paper size and make the page 
 % size more like a typical published manual.
@@ -31,7 +32,6 @@
 \newif\ifpy@doing@page@targets
 \py@doing@page@targetsfalse
 
-\newif\ifpdf\pdffalse
 \ifx\pdfoutput\undefined\else\ifcase\pdfoutput
 \else
   \pdftrue
@@ -844,7 +844,7 @@
 % Also for consistency: spell Python "Python", not "python"!
 
 % code is the most difficult one...
-%\newcommand{\code}[1]{\textrm{\@vobeyspaces\@noligs\def\{{\char`\{}\def\}{\char`\}}\def\~{\char`\~}\def\^{\char`\^}\def\e{\char`\\}\def\${\char`\$}\def\#{\char`\#}\def\&{\char`\&}\def\%{\char`\%}%
+\newcommand{\code}[1]{\textrm{\@vobeyspaces\@noligs\def\{{\char`\{}\def\}{\char`\}}\def\~{\char`\~}\def\^{\char`\^}\def\e{\char`\\}\def\${\char`\$}\def\#{\char`\#}\def\&{\char`\&}\def\%{\char`\%}%
 \texttt{#1}}}
 
 \newcommand{\bfcode}[1]{\code{\bfseries#1}} % bold-faced code font


### PR DESCRIPTION
As I mentioned in #27, I wasn't able to compile the documentation. Today I decided to tackle this problem. I identified a couple of problems that prevented my TeXLive 2015 to compile it.

First the \code command is commented out in [python.sty](https://github.com/tiarno/plastex/blob/116356ca6253aec3d2afbdf3fd1e095618cb521e/Doc/texinputs/python.sty#L847), and actually the next line doesn't make any sense without that one.

Instead of using the makeidx package (or one of its many replacements), [plastex.tex](https://github.com/tiarno/plastex/blob/116356ca6253aec3d2afbdf3fd1e095618cb521e/Doc/plastex.tex#L72) tries to directly input plastex.ind. This file doesn't exist before running LaTeX at least once.

There is some strange conflict with ipdf. pdfLaTeX complains this is defined twice.

And I corrected two mistakes in renderers.tex. In #27, I forgot  to add a column and I inserted a line at the wrong place. I didn't see it because I wasn't able to compile.

With this PR I can now compile using both pdfLaTeX and plasTeX.