### PR TITLE
Use unidecode to compute index group

### DIFF
--- a/plasTeX/Base/LaTeX/Index.py
+++ b/plasTeX/Base/LaTeX/Index.py
@@ -11,11 +11,21 @@ from plasTeX import Command, Environment, IgnoreCommand, encoding
 from plasTeX.Logging import getLogger
 from Sectioning import SectionUtils
 
+log = getLogger()
+
 try:
     from pyuca import Collator
     collator = Collator(os.path.join(os.path.dirname(__file__), 'allkeys.txt')).sort_key
 except ImportError:
     collator = lambda x: x.lower()
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    log.warning('Cannot find unidecode lib. Expect issues with index sorting')
+    def unidecode(s):
+        return s
+
     
 class hyperpage(IgnoreCommand):
     args = 'page:nox'
@@ -74,7 +84,7 @@ class IndexUtils(object):
         current = ''
         for item in self:
             try: 
-                label = title = item.sortkey[0].upper()
+                label = title = unidecode(item.sortkey[0]).upper()
                 if title in encoding.stringletters():
                     pass
                 elif title == '_':


### PR DESCRIPTION
Currently ``Base/LaTeX/Index.py`` which handles index creation does not quite work with non-ascii entries. It does use pyuca for proper ordering but then it must put entries into groups and this is where it breaks. For instance, an entry "équivalence d'homotopie" is currently put in group "Symbols" instead of "E".

It seems to me the relevant standard python lib is [unidecode](https://pypi.python.org/pypi/Unidecode) so this is what I use in this PR.

I think it's also worthwhile to discuss the following points that I met while searching for the source of the bug:

* plasTeX is currently [vendorizing](http://bitprophet.org/blog/2012/06/07/on-vendorizing/) the collation lib [pyuca](https://github.com/jtauber/pyuca). I guess this a decision was taken a long time ago. Does it  need to be reconsidered?

* ``plasTeX/encoding.py`` currently calls ``locale.getlocale`` but, as far as I can see, plasTeX nowhere calls ``locale.setlocale()`` so I think ``getlocale`` will never return anything useful. Recall that, according to [doc](https://docs.python.org/2/library/locale.html), the way to say we want to use system locale is to call ``locale.setlocale(locale.LC_ALL, '')``, it is _not_ to call ``getlocale`` without first calling ``setlocale`` as anyone would expect.