### PR TITLE
PIL shouldn't try to handle svg

### DIFF
--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -850,16 +850,20 @@ class Imager(object):
                     height = DimensionPlaceholder(tmpl.substitute({'filename':path, 'attr':'height'}))
                     height.imageUnits = width.imageUnits = self.imageUnits
                 else:
-                    img = PILImage.open(name)
-                    width, height = img.size
-                    scale = self.config['images']['scale-factor']
-                    if scale != 1:
-                        width = int(width * scale)
-                        height = int(height * scale)
-                        img.resize((width,height))
-                        img.save(path)
-                    else:
+                    if os.path.splitext(name)[1].lower() == '.svg':
                         shutil.copyfile(name, path)
+                        width = height = None
+                    else:
+                        img = PILImage.open(name)
+                        width, height = img.size
+                        scale = self.config['images']['scale-factor']
+                        if scale != 1:
+                            width = int(width * scale)
+                            height = int(height * scale)
+                            img.resize((width,height))
+                            img.save(path)
+                        else:
+                            shutil.copyfile(name, path)
                     
             # If PIL is available, convert the image to the appropriate type
             else:


### PR DESCRIPTION
PILImage doesn't know how to open svg files so it should be prevented to try to do so.