### PR TITLE
Allow macros to define post-parse callbacks

### DIFF
--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -63,6 +63,11 @@ class TeX(object):
     def __init__(self, ownerDocument=None, file=None):
         if ownerDocument is None:
             ownerDocument = self.documentClass()
+            self.toplevel = True
+        elif file:
+            self.toplevel = True
+        else:
+            self.toplevel = False
         self.ownerDocument = ownerDocument
 
         # Input source stack
@@ -434,6 +439,9 @@ class TeX(object):
             log.error('An error occurred while building the document object%s%s', self.lineInfo, msg)
             raise
 
+        if self.toplevel:
+            for callback in self.ownerDocument.post_parse_cb:
+                callback()
         return output
 
     def textTokens(self, text):

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -440,7 +440,7 @@ class TeX(object):
             raise
 
         if self.toplevel:
-            for callback in self.ownerDocument.post_parse_cb:
+            for callback in self.ownerDocument.postParseCallbacks:
                 callback()
         return output
 

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -827,7 +827,7 @@ class TeXDocument(Document):
             self.config = kwargs['config']
 
         # post parsing callbacks list
-        self.post_parse_cb = []
+        self.postParseCallbacks = []
 
     def createElement(self, name):
         elem = self.context[name]()

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -826,6 +826,9 @@ class TeXDocument(Document):
         else:
             self.config = kwargs['config']
 
+        # post parsing callbacks list
+        self.post_parse_cb = []
+
     def createElement(self, name):
         elem = self.context[name]()
         elem.parentNode = None


### PR DESCRIPTION
The goal is to allow python packages to interact with plasTeX after parsing (in particular all references are then resolved) but before rendering. This is done by putting call back functions in the document ``post_parse_cb`` list.

I can provide a detailed use case if needed.