### PR TITLE
Try to use setuptools to allow "setup.py develop"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
-
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 templates = ['*.html','*.htm','*.xml','*.zpt','*.zpts']
 images = ['*.gif','*.png','*.jpg','*.jpeg','*.js','*.htc']


### PR DESCRIPTION
This is a tiny improvement for developers: give them a chance to enjoy [setup.py develop](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode) if ``setuptools`` is available.