### PR TITLE
Adds MathEnvironmentPre and fix smallmatrix

### DIFF
--- a/plasTeX/Base/LaTeX/Math.py
+++ b/plasTeX/Base/LaTeX/Math.py
@@ -39,13 +39,23 @@ class ThinSpace_(Command):
 class MathEnvironment(Environment):
     mathMode = True
 
+class MathEnvironmentPre(MathEnvironment):
+    """
+    A math environment whose source property keeps the begin and end markup.
+    """
+    @property
+    def source(self):
+        return u"\\begin{{{0}}}{1}\\end{{{0}}}".format(
+                self.tagName,
+                sourceChildren(self))
+
 # Need \newcommand\({\begin{math}} and \newcommand\){\end{math}}
 
 class math(MathEnvironment):
     @property
     def source(self):
         if self.hasChildNodes():
-            return '$%s$' % sourceChildren(self)
+            return u'$%s$' % sourceChildren(self)
         return '$'
 
 class displaymath(MathEnvironment):

--- a/plasTeX/Packages/amsmath.py
+++ b/plasTeX/Packages/amsmath.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-from plasTeX import Command, Environment
+from plasTeX import Command
 from plasTeX.Base.LaTeX.Arrays import Array
 from plasTeX.Base.LaTeX.Math import EqnarrayStar, equation, eqnarray
 #### Imports Added by Tim ####
-from plasTeX.Base.LaTeX.Math import math
+from plasTeX.Base.LaTeX.Math import math, MathEnvironmentPre
 
 from plasTeX import Tokenizer
 from plasTeX.Logging import getLogger
@@ -99,7 +99,7 @@ class Bmatrix(Array):
     pass
 
 #### Inline Math
-class smallmatrix(math):
+class smallmatrix(MathEnvironmentPre):
     pass
 
 class dddot(math):


### PR DESCRIPTION
This should be the last of my PR preparing the big one (html5 renderer). Here I'm not sure I'm doing it right. While working on the html5 renderer, I couldn't do anything with the ``\smallmatrix`` command from the ``amsmath`` package. As far as I can tell, this command is currently broken. For instance, invoking plasTeX (upstream master branch) without argument on
```latex
\documentclass{article}

\usepackage{amsmath}

\begin{document}
Test $\left( \begin{smallmatrix} a & b \\ c & d
\end{smallmatrix}\right)$.
\end{document}
```

produces a rather disappointing result (compare with pdflatex output). The current pull request allows me to have a working ``\smallmatrix`` both with the current xhtml renderer and with my html5 renderer since it allows to keep all information. However this is getting close to areas of plasTeX that I wish I could understand better, so I may have done it wrong. I created a subclass ``MathEnvironmentPre`` of ``MathEnvironment`` which keeps the opening and closing tags inside the source.