### PR TITLE
Python 3 tests

### DIFF
--- a/plasTeX/ConfigManager/String.py
+++ b/plasTeX/ConfigManager/String.py
@@ -27,6 +27,7 @@ class StringOption(StringParser, GenericOption, UserString):
                       source=DEFAULTS['source']):
       UserString.__init__(self, '')
       GenericOption.initialize(self, locals())
+      self.data = self.data or ''
 
    def cast(self, arg):
       if arg is None: return

--- a/plasTeX/ConfigManager/__init__.py
+++ b/plasTeX/ConfigManager/__init__.py
@@ -1064,8 +1064,8 @@ class ConfigManager(UserDict, object):
         Make sure that all mandatory options have been set
 
         """
-        for section in list(self.values()):
-           for option in list(section.data.values()):
+        for section in self.values():
+           for option in section.data.values():
               if not option.mandatory: continue
               if option.getValue() in [None,[]]:
                  names = ', '.join(option.getPossibleOptions())

--- a/plasTeX/ConfigManager/__init__.py
+++ b/plasTeX/ConfigManager/__init__.py
@@ -1065,7 +1065,7 @@ class ConfigManager(UserDict, object):
 
         """
         for section in list(self.values()):
-           for option in list(section.values()):
+           for option in list(section.data.values()):
               if not option.mandatory: continue
               if option.getValue() in [None,[]]:
                  names = ', '.join(option.getPossibleOptions())

--- a/plasTeX/DOM/__init__.py
+++ b/plasTeX/DOM/__init__.py
@@ -439,6 +439,7 @@ class NamedNodeMap(dict):
             self[key] = value
 
 
+
 def _compareDocumentPosition(self, other):
     """
     Compare the position of the current node to `other`
@@ -1140,6 +1141,17 @@ class Node(object):
     def isEqualNode(self, other):
         """ Is this node equivalent to `other`? """
         return other == self
+
+    def __eq__(self, other):
+        try:
+            return (self.nodeName == other.nodeName and
+                    self.attributes == other.attributes and
+                    self.childNodes == other.childNodes)
+        except:
+            return False
+
+    def __hash__(self):
+        return id(self)
 
     def __lt__(self, other):
         try:

--- a/plasTeX/encoding.py
+++ b/plasTeX/encoding.py
@@ -4,8 +4,4 @@ import locale
 import string
 
 def stringletters():
-    encoding = locale.getlocale()[1]
-    if encoding:
-        return string.letters.decode(encoding)
-    else:
-        return string.ascii_letters
+    return string.ascii_letters

--- a/plasTeX/plastex
+++ b/plasTeX/plastex
@@ -72,7 +72,7 @@ def main(argv):
 
     # Load renderer
     try:
-        exec('from plasTeX.Renderers.%s import Renderer' % rname)
+        exec('from plasTeX.Renderers.%s import Renderer' % rname, globals())
     except ImportError as msg:
         log.error('Could not import renderer "%s".  Make sure that it is installed correctly, and can be imported by Python.' % rname)
         sys.exit(1)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = unittests
+python_files = *.py

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
-
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 templates = ['*.html','*.htm','*.xml','*.zpt','*.zpts']
 images = ['*.gif','*.png','*.jpg','*.jpeg','*.js','*.htc']

--- a/unittests/ArgumentParsing.py
+++ b/unittests/ArgumentParsing.py
@@ -107,7 +107,7 @@ class ArgumentParsing(TestCase):
         s = TeX()
         s.input('{one=1, two={\par}, three={$(x,y)$}, four=4}')
         arg = s.readArgument(type='dict')
-        keys = arg.keys()
+        keys = list(arg.keys())
         keys.sort()
         expectkeys = ['four','one','three','two']
         assert keys == expectkeys, '"%s" != "%s"' % (keys, expectkeys)
@@ -382,7 +382,7 @@ class ArgumentParsing(TestCase):
 
         s.input('{one=1, two={\mycount} , three={3}}')
         arg = s.readArgument(type='dict', expanded=True)
-        keys = arg.keys()
+        keys = list(arg.keys())
         keys.sort()
         assert keys == ['one', 'three', 'two']
 

--- a/unittests/DOM/Element.py
+++ b/unittests/DOM/Element.py
@@ -16,12 +16,12 @@ class ElementTest(TestCase):
         doc = Document()
         one = doc.createElement('one')
         one.setAttribute('foo', 'bar')
-        assert one.attributes.keys() == ['foo']
+        assert list(one.attributes.keys()) == ['foo']
         assert one.getAttribute('foo') == 'bar'
         assert one.getAttribute('aoeu') is None
         assert one.removeAttribute('aoeu') is None
         assert one.removeAttribute('foo') is None
-        assert one.attributes.keys() == []
+        assert list(one.attributes.keys()) == []
 
     def testHasAttribute(self):
         doc = Document()

--- a/unittests/Encoding.py
+++ b/unittests/Encoding.py
@@ -24,7 +24,7 @@ class Longtables(unittest.TestCase):
 
     def testString(self):
         # Bad character encoding
-        locale.setlocale(locale.LC_ALL, "en_GB.iso8859-1")
+        locale.setlocale(locale.LC_ALL, "C")
         out = self.runDocument(u"é")
 
 if __name__ == '__main__':

--- a/unittests/Encoding.py
+++ b/unittests/Encoding.py
@@ -19,7 +19,7 @@ class Longtables(unittest.TestCase):
         """
         tex = TeX()
         tex.disableLogging()
-        tex.input(ur'''\document{article}\begin{document}%s\end{document}''' % content)
+        tex.input(r'\document{article}\begin{document}%s\end{document}' % content)
         return tex.parse()
 
     def testString(self):

--- a/unittests/FunctionalTests.py
+++ b/unittests/FunctionalTests.py
@@ -61,7 +61,7 @@ class Benched(TestCase):
                 command = line[2:].strip()
                 p = Process(cwd=outdir, *command.split())
                 if p.returncode:
-                    raise OSError, 'Preprocessing command exited abnormally with return code %s: %s' % (command, p.log)
+                    raise OSError('Preprocessing command exited abnormally with return code %s: %s' % (command, p.log))
             elif line.startswith('%#'):
                 filename = line[2:].strip()
                 shutil.copyfile(os.path.join(root,'extras',filename),
@@ -83,7 +83,7 @@ class Benched(TestCase):
                     cwd=outdir)
         if p.returncode:
             shutil.rmtree(outdir, ignore_errors=True)
-            raise OSError, 'plastex failed with code %s: %s' % (p.returncode, p.log)
+            raise OSError('plastex failed with code %s: %s' % (p.returncode, p.log))
 
         # Read output file
         output = open(outfile)
@@ -99,7 +99,7 @@ class Benched(TestCase):
             newfile = os.path.join(root,'new',os.path.basename(outfile))
             open(newfile,'w').write(output.read())
             shutil.rmtree(outdir, ignore_errors=True)
-            raise OSError, 'No benchmark file: %s' % benchfile
+            raise OSError('No benchmark file: %s' % benchfile)
 
         # Compare files
         diff = ''.join(list(difflib.unified_diff(bench, output))).strip()

--- a/unittests/NewCommands.py
+++ b/unittests/NewCommands.py
@@ -194,7 +194,7 @@ class NewCommands(TestCase):
         s = TeX()
         s.input(r'\chardef\foo=65\relax\foo')
         output = [x for x in s]
-        assert output[-1].unicode == 'A', output
+        assert output[-1].str == 'A', output
 
 
 class Python(TestCase):

--- a/unittests/Packages/Alltt.py
+++ b/unittests/Packages/Alltt.py
@@ -3,7 +3,16 @@
 import unittest, re, os, tempfile, shutil
 from plasTeX.TeX import TeX
 from unittest import TestCase
-from BeautifulSoup import BeautifulSoup as Soup
+
+# Will try to use obsolete, but good enough for us, BeautifulSoup 3 if
+# BeautifulSoup 4 is not available. Need to cope with slight API difference
+try:
+    from bs4  import BeautifulSoup
+    def Soup(source):
+        return BeautifulSoup(source, 'html.parser')
+except ImportError:
+    from BeautifulSoup import BeautifulSoup as Soup
+
 
 class Alltt(TestCase):
 
@@ -24,12 +33,12 @@ class Alltt(TestCase):
 
     def runPreformat(self, content):
         """
-        This method compiles and renders a document fragment and 
+        This method compiles and renders a document fragment and
         returns the result
 
         Arguments:
         content - string containing the document fragment
-      
+
         Returns: content of output file
 
         """

--- a/unittests/Packages/Longtable.py
+++ b/unittests/Packages/Longtable.py
@@ -19,7 +19,7 @@ class Longtables(TestCase):
         """
         tex = TeX()
         tex.disableLogging()
-        tex.input(r'''\document{article}\usepackage{longtable}\begin{document}%s\end{document}''' % content)
+        tex.input(r'''\documentclass{article}\usepackage{longtable}\begin{document}%s\end{document}''' % content)
         return tex.parse()
 
     def runTable(self, content):

--- a/unittests/Packages/Longtable.py
+++ b/unittests/Packages/Longtable.py
@@ -156,24 +156,15 @@ class Longtables(TestCase):
         for caption in captions:
             doc = self.runDocument(r'''\begin{longtable}{lll} %s 1 & 2 & 3 \end{longtable}''' % caption)
 
-            # Make sure that we only have one caption
+            # Make sure the caption has been captured by longtable
             caption = doc.getElementsByTagName('caption')
-            assert len(caption) == 1, 'Too many captions'
-            caption = caption[0]
+            assert not caption, 'Too many captions'
 
             # Make sure that the caption node matches the caption on the table
             table = doc.getElementsByTagName('longtable')[0]
+            caption = table.title
             assert caption is not None, 'Caption is empty'
-            assert table.caption is not None, 'Table caption is empty'
-            assert table.caption is caption, 'Caption does not match table caption'
-
-            # Make sure that the caption is the sibling of the caption
-            assert table.previousSibling is caption, 'Previous sibling is not the caption'
-            assert caption.nextSibling is table, 'Next sibling is not the table'
-
-            # Make sure that we got the right caption
-            text = caption.textContent.strip()
-            assert text == 'Caption Text', 'Caption text should be "Caption Text", but is "%s"' % text
+            assert table.title.textContent.strip() == u'Caption Text', 'Caption does not match table caption'
 
     def testKill(self):
         doc = self.runDocument(r'''\begin{longtable}{lll} 1 & 2 & 3 \\ longtext & & \kill\end{longtable}''')

--- a/unittests/Packages/Longtable.py
+++ b/unittests/Packages/Longtable.py
@@ -3,7 +3,16 @@
 import unittest, re, os, tempfile, shutil
 from plasTeX.TeX import TeX
 from unittest import TestCase
-from BeautifulSoup import BeautifulSoup as Soup
+
+# Will try to use obsolete, but good enough for us, BeautifulSoup 3 if
+# BeautifulSoup 4 is not available. Need to cope with slight API difference
+try:
+    from bs4  import BeautifulSoup
+    def Soup(source):
+        return BeautifulSoup(source, 'html.parser')
+except ImportError:
+    from BeautifulSoup import BeautifulSoup as Soup
+
 
 class Longtables(TestCase):
 
@@ -24,12 +33,12 @@ class Longtables(TestCase):
 
     def runTable(self, content):
         """
-        This method compiles and renders a document fragment and 
+        This method compiles and renders a document fragment and
         returns the result
 
         Arguments:
         content - string containing the document fragment
-      
+
         Returns: content of output file
 
         """
@@ -61,10 +70,10 @@ class Longtables(TestCase):
 
         numcols = len(out.findAll('tr')[0].findAll('td'))
         assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s): %s' % (numcols, out)
-        
+
         numcols = len(out.findAll('tr')[1].findAll('td'))
         assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s): %s' % (numcols, out)
-        
+
 
     def testHeaders(self):
         headers = [
@@ -89,7 +98,7 @@ class Longtables(TestCase):
             assert text[0]=='M','Cell should contain M, but contains %s' % text[0]
             assert text[1]=='N','Cell should contain N, but contains %s' % text[1]
             assert text[2]=='O','Cell should contain O, but contains %s' % text[2]
-        
+
             numcols = len(out.findAll('tr')[1].findAll('td'))
             assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s) - %s - %s' % (numcols, header, out)
 
@@ -141,7 +150,7 @@ class Longtables(TestCase):
             assert text[0]=='F','Cell should contain F, but contains %s' % text[0]
             assert text[1]=='G','Cell should contain G, but contains %s' % text[1]
             assert text[2]=='H','Cell should contain H, but contains %s' % text[2]
-        
+
             numcols = len(out.findAll('tr')[1].findAll('td'))
             assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s) - %s - %s' % (numcols, header, out)
 
@@ -149,7 +158,7 @@ class Longtables(TestCase):
         captions = [
             r'\caption{Caption Text}\\',
             r'\caption{Caption Text}\\ A & B & C \\\endfirsthead',
-            r'''\caption{Caption Text}\\ A & B & C \\\endfirsthead 
+            r'''\caption{Caption Text}\\ A & B & C \\\endfirsthead
                 \caption{Next Caption Text}\\ X & Y & Z \\\endhead''',
         ]
 
@@ -174,7 +183,7 @@ class Longtables(TestCase):
         assert len(rows) == 1, 'There should be only 1 row, but found %s' % len(rows)
         content = re.sub(r'\s+', r' ', rows[0].textContent.strip())
         assert content == '1 2 3', 'Content should be "1 2 3", but is %s' % content
-        
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR mostly puts the test status at the same level in python 2 and python 3. It means all unit tests pass but some functional tests don't.

However it also incorporates the fixes discussed in #65 and #67. The only thing that is clearly wrong is a change in encoding.py. That file forbid me to do any work on python3 branch but this will be discussed elsewhere.