### PR TITLE
Python3 compiles its doc

### DIFF
--- a/Doc/plastex.tex
+++ b/Doc/plastex.tex
@@ -2,6 +2,7 @@
 
 \usepackage[T1]{fontenc}
 \usepackage{graphicx}
+\usepackage{makeidx}
 \usepackage{hyperref}
 
 \newcommand{\titleref}{\ref}
@@ -69,6 +70,6 @@
 
 \input{parsing-faq}
 
-\input{plastex.ind}
+\printindex
 
 \end{document}

--- a/Doc/texinputs/python.sty
+++ b/Doc/texinputs/python.sty
@@ -7,6 +7,7 @@
              [1998/01/11 LaTeX package (Python markup)]
 
 \RequirePackage{longtable}
+\RequirePackage{ifpdf}
 
 % Uncomment these two lines to ignore the paper size and make the page 
 % size more like a typical published manual.
@@ -31,7 +32,6 @@
 \newif\ifpy@doing@page@targets
 \py@doing@page@targetsfalse
 
-\newif\ifpdf\pdffalse
 \ifx\pdfoutput\undefined\else\ifcase\pdfoutput
 \else
   \pdftrue
@@ -844,7 +844,7 @@
 % Also for consistency: spell Python "Python", not "python"!
 
 % code is the most difficult one...
-%\newcommand{\code}[1]{\textrm{\@vobeyspaces\@noligs\def\{{\char`\{}\def\}{\char`\}}\def\~{\char`\~}\def\^{\char`\^}\def\e{\char`\\}\def\${\char`\$}\def\#{\char`\#}\def\&{\char`\&}\def\%{\char`\%}%
+\newcommand{\code}[1]{\textrm{\@vobeyspaces\@noligs\def\{{\char`\{}\def\}{\char`\}}\def\~{\char`\~}\def\^{\char`\^}\def\e{\char`\\}\def\${\char`\$}\def\#{\char`\#}\def\&{\char`\&}\def\%{\char`\%}%
 \texttt{#1}}}
 
 \newcommand{\bfcode}[1]{\code{\bfseries#1}} % bold-faced code font

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -201,7 +201,7 @@ class TeX(object):
                 flag = plasTeX.Command()
                 self.pushToken(flag)
                 self.input(f)
-                self.ownerDocument.context.packages[file] = options or {}
+                self.ownerDocument.context.packages[myfile] = options or {}
                 for tok in self:
                     if tok is flag:
                         break


### PR DESCRIPTION
In the end I had no time to update the html5 documentation tonight. But I managed to compile the plasTeX documentation using the python3 branch!

It turns out that, in addition to fixes from 9599b08, I was only two characters away from success.