### PR TITLE
No mutable default values

### DIFF
--- a/plasTeX/Base/LaTeX/Arrays.py
+++ b/plasTeX/Base/LaTeX/Arrays.py
@@ -19,7 +19,8 @@ class ColumnType(Macro):
         self.style.update(self.columnAttributes)
         
     @classmethod
-    def new(cls, name, attributes, args='', before=[], after=[], between=[]):
+    def new(cls, name, attributes, args='', 
+            before=None, after=None, between=None):
         """
         Generate a new column type definition
 
@@ -35,7 +36,9 @@ class ColumnType(Macro):
         """
         newclass = new.classobj(name, (cls,), 
             {'columnAttributes':attributes, 'args':args,
-             'before':before, 'after':after, 'between':between})
+             'before':before or [], 
+             'after':after or [], 
+             'between':between or []})
         cls.columnTypes[name] = newclass
 
     def __repr__(self):

--- a/plasTeX/Base/LaTeX/Packages.py
+++ b/plasTeX/Base/LaTeX/Packages.py
@@ -19,9 +19,10 @@ status = getLogger('status')
 
 class PackageLoader(Command):
     extension = '.sty'
-    def load(self, tex, file, options={}):
+    def load(self, tex, file, options=None):
         try:
-            self.ownerDocument.context.loadPackage(tex, file+self.extension, options)
+            self.ownerDocument.context.loadPackage(
+                    tex, file+self.extension, options or {})
         except Exception, msg:
             log.error('Could not load package "%s": %s' % (file, msg)) 
 

--- a/plasTeX/Base/LaTeX/Verbatim.py
+++ b/plasTeX/Base/LaTeX/Verbatim.py
@@ -76,7 +76,7 @@ class verbatim(Environment):
 
         return tokens
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         """ Normalize, but don't allow character substitutions """
         return Environment.normalize(self)
 
@@ -130,7 +130,7 @@ class verb(Command):
                                  self.delimiter, sourceChildren(self), 
                                  self.delimiter)
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         """ Normalize, but don't allow character substitutions """
         return Command.normalize(self)
 

--- a/plasTeX/ConfigManager/Multi.py
+++ b/plasTeX/ConfigManager/Multi.py
@@ -38,7 +38,7 @@ class MultiOption(MultiParser, GenericOption, UserList):
 
    def __init__(self, docstring=DEFAULTS['docstring'],
                       options=DEFAULTS['options'],
-                      default=[],
+                      default=None,
                       optional=DEFAULTS['optional'],
                       values=DEFAULTS['values'],
                       category=DEFAULTS['category'],
@@ -47,7 +47,7 @@ class MultiOption(MultiParser, GenericOption, UserList):
                       environ=DEFAULTS['environ'],
                       registry=DEFAULTS['registry'],
                       delim=',',
-                      range=[1,'*'],
+                      range=None,
                       mandatory=None,
                       name=DEFAULTS['name'],
                       source=DEFAULTS['source'],
@@ -62,8 +62,9 @@ class MultiOption(MultiParser, GenericOption, UserList):
       list is assumed to be delimited by whitespace.
 
       """
+      default = default or []
       self.delim = delim
-      self.range = range
+      self.range = range or [1, '*']
       assert not issubclass(template, MultiOption), \
              'MultiOptions can not have a MultiOption as a template'
       assert issubclass(template, GenericOption), \
@@ -189,7 +190,7 @@ class MultiArgument(GenericArgument, MultiOption):
 
    def __init__(self, docstring=DEFAULTS['docstring'],
                       options=DEFAULTS['options'],
-                      default=[],
+                      default=None,
                       optional=DEFAULTS['optional'],
                       values=DEFAULTS['values'],
                       category=DEFAULTS['category'],
@@ -198,14 +199,15 @@ class MultiArgument(GenericArgument, MultiOption):
                       environ=DEFAULTS['environ'],
                       registry=DEFAULTS['registry'],
                       delim=' ',
-                      range=[1,'*'],
+                      range=None,
                       mandatory=None,
                       name=DEFAULTS['name'],
                       source=DEFAULTS['source'],
                       template=StringOption):
       """ Initialize a multi argument """
       self.delim = delim
-      self.range = range
+      self.range = range or [1,'*']
+      default = default or []
       assert not issubclass(template, MultiArgument), \
              'MultiArguments can not have a MultiArguments as a template'
       assert not issubclass(template, MultiOption), \

--- a/plasTeX/ConfigManager/__init__.py
+++ b/plasTeX/ConfigManager/__init__.py
@@ -194,7 +194,7 @@ class MissingSectionHeaderError(ParsingError):
 class ConfigSection(UserDict, object):
     """ Section of a configuration object """
 
-    def __init__(self, name, data={}):
+    def __init__(self, name, data=None):
         """
         Initialize the section
 
@@ -203,7 +203,7 @@ class ConfigSection(UserDict, object):
         data -- dictionary containing the initial set of options
 
         """
-        UserDict.__init__(self, data)
+        UserDict.__init__(self, data or {})
         self.name = name
         self.parent = None
 
@@ -296,7 +296,7 @@ class ConfigSection(UserDict, object):
             raise ValueError, 'Not a boolean: %s' % v
         return val
 
-    def get(self, option, raw=0, vars={}):
+    def get(self, option, raw=0, vars=None):
         """
         Get an option value for a given section.
 
@@ -319,6 +319,7 @@ class ConfigSection(UserDict, object):
         value of the option
 
         """
+        vars = vars or {}
         value = self.getraw(option, vars)
 
         # Raw was specified
@@ -377,7 +378,7 @@ class ConfigSection(UserDict, object):
             raise InterpolationDepthError(option, self.name, rawval)
         return value
 
-    def getraw(self, option, vars={}):
+    def getraw(self, option, vars=None):
         """
         Return raw value of option
 
@@ -388,6 +389,7 @@ class ConfigSection(UserDict, object):
         vars -- dictionary containing additional default values
 
         """
+        vars = vars or {}
         if vars.has_key(option):
             return vars[option].getValue()
 
@@ -473,7 +475,7 @@ class ConfigManager(UserDict, object):
     short_prefix = '-'
     long_prefix = '--'
 
-    def __init__(self, defaults={}):
+    def __init__(self, defaults=None):
         """
         Initialize ConfigManager
 
@@ -483,7 +485,7 @@ class ConfigManager(UserDict, object):
 
         """
         UserDict.__init__(self)
-        self[DEFAULTSECT] = ConfigSection(DEFAULTSECT, defaults)
+        self[DEFAULTSECT] = ConfigSection(DEFAULTSECT, defaults or {})
         self.strict = 1     # Raise exception for unknown options
         self._categories = {}  # Dictionary of option categories
         self.unrecognized = []
@@ -687,9 +689,9 @@ class ConfigManager(UserDict, object):
         self.__read(fp, filename)
         return self
 
-    def get(self, section, option, raw=0, vars={}):
+    def get(self, section, option, raw=0, vars=None):
         """ Get an option value for a given section """
-        return self[section].get(option, raw, vars)
+        return self[section].get(option, raw, vars or {})
 
     def set(self, section, option, value, source=BUILTIN):
         """ Set an option value """
@@ -1436,9 +1438,9 @@ class ConfigManager(UserDict, object):
               return options
         return ''
 
-    def usage(self, categories=[]):
+    def usage(self, categories=None):
         """ Print descriptions of all command line options """
-        categories = categories[:]
+        categories = categories or []
         options = []
         for section in self.values():
             for option in section.data.values():
@@ -1511,8 +1513,8 @@ class ConfigManager(UserDict, object):
 class CommandLineManager(ordereddict):
    """ Command-Line Argument Manager """
 
-   def __init__(self, data={}):
-      ordereddict.__init__(self, data)
+   def __init__(self, data=None):
+      ordereddict.__init__(self, data or {})
       self._associations = {}
 
    def usage(self):

--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -23,8 +23,8 @@ class ContextItem(dict):
 
     """
 
-    def __init__(self, data={}):
-        dict.__init__(self, data)
+    def __init__(self, data=None):
+        dict.__init__(self, data or {})
         self.categories = None
         self.obj = None
         self.parent = None
@@ -84,8 +84,8 @@ class Counters(dict):
 class LanguageParser(object):
     """ Parser for language commands """
 
-    def __init__(self, output={}):
-        self.data = output
+    def __init__(self, output=None):
+        self.data = output or {}
         self.language = None
         self.term = None
 
@@ -364,7 +364,7 @@ class Context(object):
                                                 {'args': value})
             self.importMacros(macros)
 
-    def loadPackage(self, tex, file, options={}):
+    def loadPackage(self, tex, file, options=None):
         """
         Load a Python or LaTeX package
 
@@ -384,6 +384,7 @@ class Context(object):
         boolean indicating whether or not the package loaded successfully
 
         """
+        options = options or {}
         module = os.path.splitext(file)[0]
 
         # See if it has already been loaded
@@ -398,7 +399,7 @@ class Context(object):
             m = __import__(module, globals(), locals())
             status.info(' ( %s ' % m.__file__)
             if hasattr(m, 'ProcessOptions'):
-                m.ProcessOptions(options or {}, tex.ownerDocument)
+                m.ProcessOptions(options, tex.ownerDocument)
             self.importMacros(vars(m))
             moduleini = os.path.splitext(m.__file__)[0]+'.ini'
             self.loadINIPackage([packagesini, moduleini])

--- a/plasTeX/DOM/__init__.py
+++ b/plasTeX/DOM/__init__.py
@@ -986,8 +986,9 @@ class Node(object):
 
     __iadd__ = extend
 
-    def appendText(self, text, charsubs=[], setParent=True):
+    def appendText(self, text, charsubs=None, setParent=True):
         """ Append a list of text nodes as one node """
+        charsubs = charsubs or []
         if not text:
             return
         value = u''.join(text)
@@ -1054,7 +1055,7 @@ class Node(object):
                     node.append(x)
         return node 
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         """ 
         Combine consecutive text nodes and remove comments 
 
@@ -1065,6 +1066,7 @@ class Node(object):
             source to.
 
         """
+        charsubs = charsubs or []
         if self.hasAttributes():
             for value in self.attributes.values():
                 if isinstance(value, Node):
@@ -1678,7 +1680,7 @@ class CharacterData(unicode, Node):
     removeChild = _notImplemented
     appendChild = _notImplemented
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         pass
 
     @property
@@ -1833,7 +1835,7 @@ class DOMConfiguration(dict):
     http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#DOMConfiguration
     """
 
-    def __init__(self, data={}):
+    def __init__(self, data=None):
         dict.__init__(self, data)
         self['canonical-form'] = False
         self['cdata-sections'] = True

--- a/plasTeX/Filenames.py
+++ b/plasTeX/Filenames.py
@@ -4,7 +4,8 @@ import re, string, os.path
 
 class Filenames(object):
 
-    def __init__(self, spec, charsub=[], vars={}, extension='', invalid={}):
+    def __init__(self, spec, charsub=None, vars=None, extension='',
+            invalid=None):
         """
         Generate filenames based on the `spec' and using the given vars
     
@@ -74,10 +75,10 @@ class Filenames(object):
     
         """      
         self.files = self.parseFilenames(spec)
-        self.charsub = charsub
-        self.vars = vars
+        self.charsub = charsub or []
+        self.vars = vars or {}
         self.extension = extension
-        self.invalid = invalid
+        self.invalid = invalid or {}
         self.newFilename = self._newFilename()
 
     def parseFilenames(self, spec):

--- a/plasTeX/Packages/color.py
+++ b/plasTeX/Packages/color.py
@@ -42,7 +42,8 @@ def ProcessOptions(options, document):
     colors['middlegray'] = latex2htmlcolor('0.7')
     colors['lightgray'] = latex2htmlcolor('0.9')
 
-def latex2htmlcolor(arg, model='rgb', named={}):
+def latex2htmlcolor(arg, model='rgb', named=None):
+    named = named or {}
     if model == 'named':
         return named.get(arg, '')
     if ',' in arg:

--- a/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
+++ b/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
@@ -830,7 +830,7 @@ class TemplateCompiler:
 		else:
 			self.commandList.append (command)
 		
-	def addTag (self, tag, tagProperties={}):
+	def addTag (self, tag, tagProperties=None):
 		""" Used to add a tag to the stack.  Various properties can be passed in the dictionary
 		    as being information required by the tag.
 		    Currently supported properties are:
@@ -841,10 +841,11 @@ class TemplateCompiler:
 					'singletonTag'    - A boolean to indicate that this is a singleton flag
 		"""
 		# Add the tag to the tagStack (list of tuples (tag, properties, useMacroLocation))
+                tagProperties = tagProperties or {}
 		self.log.debug ("Adding tag %s to stack" % tag[0])
-		command = tagProperties.get ('command',None)
-		originalAtts = tagProperties.get ('originalAtts', None)
-		singletonTag = tagProperties.get ('singletonTag', 0)
+		command = tagProperties.get('command', None)
+		originalAtts = tagProperties.get('originalAtts', None)
+		singletonTag = tagProperties.get('singletonTag', 0)
 		if (command is not None):
 			if (command[0] == METAL_USE_MACRO):
 				self.tagStack.append ((tag, tagProperties, len (self.commandList)+1))

--- a/plasTeX/Renderers/__init__.py
+++ b/plasTeX/Renderers/__init__.py
@@ -347,8 +347,8 @@ class Renderer(dict):
     imageUnits = '&${units};'
     encodingErrors = 'replace'
 
-    def __init__(self, data={}):
-        dict.__init__(self, data)
+    def __init__(self, data=None):
+        dict.__init__(self, data or {})
 
         # Names of generated files
         self.files = {}

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -172,7 +172,7 @@ class TeX(object):
         if self.inputs:
             self.currentInput = self.inputs[-1]
 
-    def loadPackage(self, file, options={}):
+    def loadPackage(self, file, options=None):
         """
         Load a LaTeX package
 


### PR DESCRIPTION
Fixes #77 and maybe other unknown bugs.

Remove mutable in function default values except in few cases where the value is copied anyway. This is a systematic change. I'm aware it may introduce other bugs (all tests that used to pass still pass though) so I would understand if you prefer to fix only ``Filenames.py``.