### PR TITLE
Default values for python 3

### DIFF
--- a/plasTeX/Base/LaTeX/Arrays.py
+++ b/plasTeX/Base/LaTeX/Arrays.py
@@ -19,7 +19,8 @@ class ColumnType(Macro):
         self.style.update(self.columnAttributes)
 
     @classmethod
-    def new(cls, name, attributes, args='', before=[], after=[], between=[]):
+    def new(cls, name, attributes, args='', 
+            before=None, after=None, between=None):
         """
         Generate a new column type definition
 
@@ -35,7 +36,9 @@ class ColumnType(Macro):
         """
         newclass = type(name, (cls,),
             {'columnAttributes':attributes, 'args':args,
-             'before':before, 'after':after, 'between':between})
+             'before': before or [], 
+             'after': after or [], 
+             'between': between or []})
         cls.columnTypes[name] = newclass
 
     def __repr__(self):

--- a/plasTeX/Base/LaTeX/Packages.py
+++ b/plasTeX/Base/LaTeX/Packages.py
@@ -18,9 +18,10 @@ status = getLogger('status')
 
 class PackageLoader(Command):
     extension = '.sty'
-    def load(self, tex, file, options={}):
+    def load(self, tex, file, options=None):
         try:
-            self.ownerDocument.context.loadPackage(tex, file+self.extension, options)
+            self.ownerDocument.context.loadPackage(
+                    tex, file+self.extension, options or {})
         except Exception as msg:
             log.error('Could not load package "%s": %s' % (file, msg))
 

--- a/plasTeX/Base/LaTeX/Verbatim.py
+++ b/plasTeX/Base/LaTeX/Verbatim.py
@@ -76,7 +76,7 @@ class verbatim(Environment):
 
         return tokens
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         """ Normalize, but don't allow character substitutions """
         return Environment.normalize(self)
 
@@ -130,6 +130,6 @@ class verb(Command):
                                  self.delimiter, sourceChildren(self),
                                  self.delimiter)
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         """ Normalize, but don't allow character substitutions """
         return Command.normalize(self)

--- a/plasTeX/ConfigManager/Generic.py
+++ b/plasTeX/ConfigManager/Generic.py
@@ -50,10 +50,10 @@ class GenericParser:
 
       return 0
 
-   def getArgument(self, args, range=[1,1], delim=',', forcedarg=False):
+   def getArgument(self, args, range=None, delim=',', forcedarg=False):
       """ Parse argument """
 
-      range = self.validateRange(range[:])
+      range = self.validateRange(range or [1, 1])
 
       # If we have an optional default, make sure that the range reflects that
       if range[0] < 2 and self.optional not in [None, [], ()]:
@@ -149,9 +149,9 @@ class GenericParser:
 
       return new_args, args
 
-   def _getSpaceDelimitedArguments(self, args, range=[1,'*']):
+   def _getSpaceDelimitedArguments(self, args, range=None):
       """ Slurp up any following arguments that don't begin with '-' """
-      minimum, maximum = self.validateRange(range)
+      minimum, maximum = self.validateRange(range or [1, '*'])
       arg_len = len(args)
       new_args = []
       while ConfigManager.has_following_argument(args):

--- a/plasTeX/ConfigManager/Multi.py
+++ b/plasTeX/ConfigManager/Multi.py
@@ -39,7 +39,7 @@ class MultiOption(MultiParser, GenericOption, UserList):
 
    def __init__(self, docstring=DEFAULTS['docstring'],
                       options=DEFAULTS['options'],
-                      default=[],
+                      default=None,
                       optional=DEFAULTS['optional'],
                       values=DEFAULTS['values'],
                       category=DEFAULTS['category'],
@@ -48,7 +48,7 @@ class MultiOption(MultiParser, GenericOption, UserList):
                       environ=DEFAULTS['environ'],
                       registry=DEFAULTS['registry'],
                       delim=',',
-                      range=[1,'*'],
+                      range=None,
                       mandatory=None,
                       name=DEFAULTS['name'],
                       source=DEFAULTS['source'],
@@ -64,7 +64,8 @@ class MultiOption(MultiParser, GenericOption, UserList):
 
       """
       self.delim = delim
-      self.range = range
+      default = default = []
+      self.range = range or [1, '*']
       assert not issubclass(template, MultiOption), \
              'MultiOptions can not have a MultiOption as a template'
       assert issubclass(template, GenericOption), \
@@ -190,7 +191,7 @@ class MultiArgument(GenericArgument, MultiOption):
 
    def __init__(self, docstring=DEFAULTS['docstring'],
                       options=DEFAULTS['options'],
-                      default=[],
+                      default=None,
                       optional=DEFAULTS['optional'],
                       values=DEFAULTS['values'],
                       category=DEFAULTS['category'],
@@ -199,14 +200,15 @@ class MultiArgument(GenericArgument, MultiOption):
                       environ=DEFAULTS['environ'],
                       registry=DEFAULTS['registry'],
                       delim=' ',
-                      range=[1,'*'],
+                      range=None,
                       mandatory=None,
                       name=DEFAULTS['name'],
                       source=DEFAULTS['source'],
                       template=StringOption):
       """ Initialize a multi argument """
       self.delim = delim
-      self.range = range
+      default = default or []
+      self.range = range or [1, '*']
       assert not issubclass(template, MultiArgument), \
              'MultiArguments can not have a MultiArguments as a template'
       assert not issubclass(template, MultiOption), \

--- a/plasTeX/ConfigManager/__init__.py
+++ b/plasTeX/ConfigManager/__init__.py
@@ -1511,7 +1511,7 @@ class ConfigManager(UserDict, object):
 class CommandLineManager(OrderedDict):
    """ Command-Line Argument Manager """
 
-   def __init__(self, data=None}):
+   def __init__(self, data=None):
       OrderedDict.__init__(self, data or {})
       self._associations = {}
 

--- a/plasTeX/ConfigManager/__init__.py
+++ b/plasTeX/ConfigManager/__init__.py
@@ -316,7 +316,7 @@ class ConfigSection(UserDict, object):
         value of the option
 
         """
-        vars = vars or None
+        vars = vars or {}
         value = self.getraw(option, vars)
 
         # Raw was specified
@@ -690,7 +690,7 @@ class ConfigManager(UserDict, object):
 
     def get(self, section, option, raw=0, vars=None):
         """ Get an option value for a given section """
-        return self[section].get(option, raw, vars or None)
+        return self[section].get(option, raw, vars or {})
 
     def set(self, section, option, value, source=BUILTIN):
         """ Set an option value """

--- a/plasTeX/ConfigManager/__init__.py
+++ b/plasTeX/ConfigManager/__init__.py
@@ -192,7 +192,7 @@ class MissingSectionHeaderError(ParsingError):
 class ConfigSection(UserDict, object):
     """ Section of a configuration object """
 
-    def __init__(self, name, data={}):
+    def __init__(self, name, data=None):
         """
         Initialize the section
 
@@ -201,7 +201,7 @@ class ConfigSection(UserDict, object):
         data -- dictionary containing the initial set of options
 
         """
-        UserDict.__init__(self, data)
+        UserDict.__init__(self, data or {})
         self.name = name
         self.parent = None
 
@@ -293,7 +293,7 @@ class ConfigSection(UserDict, object):
             raise ValueError('Not a boolean: %s' % v)
         return val
 
-    def get(self, option, raw=0, vars={}):
+    def get(self, option, raw=0, vars=None):
         """
         Get an option value for a given section.
 
@@ -316,6 +316,7 @@ class ConfigSection(UserDict, object):
         value of the option
 
         """
+        vars = vars or None
         value = self.getraw(option, vars)
 
         # Raw was specified
@@ -374,7 +375,7 @@ class ConfigSection(UserDict, object):
             raise InterpolationDepthError(option, self.name, rawval)
         return value
 
-    def getraw(self, option, vars={}):
+    def getraw(self, option, vars=None):
         """
         Return raw value of option
 
@@ -385,6 +386,7 @@ class ConfigSection(UserDict, object):
         vars -- dictionary containing additional default values
 
         """
+        vars = vars or {}
         if option in list(vars.keys()):
             return vars[option].getValue()
 
@@ -470,7 +472,7 @@ class ConfigManager(UserDict, object):
     short_prefix = '-'
     long_prefix = '--'
 
-    def __init__(self, defaults={}):
+    def __init__(self, defaults=None):
         """
         Initialize ConfigManager
 
@@ -479,6 +481,7 @@ class ConfigManager(UserDict, object):
            make up the section by the name DEFAULTSECT.
 
         """
+        defaults = defaults or {}
         UserDict.__init__(self)
         self[DEFAULTSECT] = ConfigSection(DEFAULTSECT, defaults)
         self.strict = 1     # Raise exception for unknown options
@@ -685,9 +688,9 @@ class ConfigManager(UserDict, object):
         self.__read(fp, filename)
         return self
 
-    def get(self, section, option, raw=0, vars={}):
+    def get(self, section, option, raw=0, vars=None):
         """ Get an option value for a given section """
-        return self[section].get(option, raw, vars)
+        return self[section].get(option, raw, vars or None)
 
     def set(self, section, option, value, source=BUILTIN):
         """ Set an option value """
@@ -1433,9 +1436,9 @@ class ConfigManager(UserDict, object):
               return options
         return ''
 
-    def usage(self, categories=[]):
+    def usage(self, categories=None):
         """ Print descriptions of all command line options """
-        categories = categories[:]
+        categories = categories or []
         options = []
         for section in list(self.values()):
             for option in list(section.data.values()):
@@ -1508,8 +1511,8 @@ class ConfigManager(UserDict, object):
 class CommandLineManager(OrderedDict):
    """ Command-Line Argument Manager """
 
-   def __init__(self, data={}):
-      OrderedDict.__init__(self, data)
+   def __init__(self, data=None}):
+      OrderedDict.__init__(self, data or {})
       self._associations = {}
 
    def usage(self):

--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -371,7 +371,7 @@ class Context(object):
                                                 {'args': value})
             self.importMacros(macros)
 
-    def loadPackage(self, tex, file, options={}):
+    def loadPackage(self, tex, file, options=None):
         """
         Load a Python or LaTeX package
 
@@ -391,6 +391,7 @@ class Context(object):
         boolean indicating whether or not the package loaded successfully
 
         """
+        options = options or {}
         module = os.path.splitext(file)[0]
         # See if it has already been loaded
         if module in list(self.packages.keys()):
@@ -404,7 +405,7 @@ class Context(object):
             m = __import__(module, globals(), locals())
             status.info(' ( %s ' % m.__file__)
             if hasattr(m, 'ProcessOptions'):
-                m.ProcessOptions(options or {}, tex.ownerDocument)
+                m.ProcessOptions(options, tex.ownerDocument)
 
             self.importMacros(vars(m))
             moduleini = os.path.splitext(m.__file__)[0] + '.ini'

--- a/plasTeX/DOM/__init__.py
+++ b/plasTeX/DOM/__init__.py
@@ -989,8 +989,9 @@ class Node(object):
 
     __iadd__ = extend
 
-    def appendText(self, text, charsubs=[], setParent=True):
+    def appendText(self, text, charsubs=None, setParent=True):
         """ Append a list of text nodes as one node """
+        charsubs = charsubs or []
         if not text:
             return
         value = ''.join(text)
@@ -1057,7 +1058,7 @@ class Node(object):
                     node.append(x)
         return node
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         """
         Combine consecutive text nodes and remove comments
 
@@ -1068,6 +1069,7 @@ class Node(object):
             source to.
 
         """
+        charsubs = charsubs or []
         if self.hasAttributes():
             for value in list(self.attributes.values()):
                 if isinstance(value, Node):
@@ -1692,7 +1694,7 @@ class CharacterData(str, Node):
     removeChild = _notImplemented
     appendChild = _notImplemented
 
-    def normalize(self, charsubs=[]):
+    def normalize(self, charsubs=None):
         pass
 
     @property
@@ -1844,8 +1846,8 @@ class DOMConfiguration(dict):
     http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#DOMConfiguration
     """
 
-    def __init__(self, data={}):
-        dict.__init__(self, data)
+    def __init__(self, data=None):
+        dict.__init__(self, data or {})
         self['canonical-form'] = False
         self['cdata-sections'] = True
         self['check-character-normalization'] = False

--- a/plasTeX/Filenames.py
+++ b/plasTeX/Filenames.py
@@ -4,7 +4,8 @@ import re, string, os.path
 
 class Filenames(object):
 
-    def __init__(self, spec, charsub=[], variables={}, extension='', invalid={}):
+    def __init__(self, spec, charsub=None, variables=None, extension='',
+            invalid=None):
         """
         Generate filenames based on the `spec' and using the given variables
 
@@ -74,10 +75,10 @@ class Filenames(object):
 
         """
         self.files = self.parseFilenames(spec)
-        self.charsub = charsub
-        self.variables = variables
+        self.charsub = charsub or []
+        self.variables = variables or {}
         self.extension = extension
-        self.invalid = invalid
+        self.invalid = invalid or {}
         self.newFilename = self._newFilename()
 
     def parseFilenames(self, spec):

--- a/plasTeX/Packages/color.py
+++ b/plasTeX/Packages/color.py
@@ -42,7 +42,8 @@ def ProcessOptions(options, document):
     colors['middlegray'] = latex2htmlcolor('0.7')
     colors['lightgray'] = latex2htmlcolor('0.9')
 
-def latex2htmlcolor(arg, model='rgb', named={}):
+def latex2htmlcolor(arg, model='rgb', named=None):
+    named = named or {}
     if model == 'named':
         return named.get(arg, '')
     if ',' in arg:

--- a/plasTeX/Renderers/ManPage/__init__.py
+++ b/plasTeX/Renderers/ManPage/__init__.py
@@ -235,7 +235,7 @@ class ManPageRenderer(BaseRenderer):
     # Lists
 
     def do_itemize(self, node):
-        output =['','.Bl -bullet -offset 3n -compact']
+        output = ['', '.Bl -bullet -offset 3n -compact']
         for item in node:
             output.append('.It')
             output.append(str(item).strip())

--- a/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
+++ b/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
@@ -843,7 +843,7 @@ class TemplateCompiler:
 					'singletonTag'    - A boolean to indicate that this is a singleton flag
 		"""
 		# Add the tag to the tagStack (list of tuples (tag, properties, useMacroLocation))
-                tagProperties = tagProperties or {}
+		tagProperties = tagProperties or {}
 		self.log.debug ("Adding tag %s to stack" % tag[0])
 		command = tagProperties.get ('command',None)
 		originalAtts = tagProperties.get ('originalAtts', None)

--- a/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
+++ b/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
@@ -832,7 +832,7 @@ class TemplateCompiler:
 		else:
 			self.commandList.append (command)
 
-	def addTag (self, tag, tagProperties={}):
+	def addTag (self, tag, tagProperties=None):
 		""" Used to add a tag to the stack.  Various properties can be passed in the dictionary
 		    as being information required by the tag.
 		    Currently supported properties are:
@@ -843,6 +843,7 @@ class TemplateCompiler:
 					'singletonTag'    - A boolean to indicate that this is a singleton flag
 		"""
 		# Add the tag to the tagStack (list of tuples (tag, properties, useMacroLocation))
+                tagProperties = tagProperties or {}
 		self.log.debug ("Adding tag %s to stack" % tag[0])
 		command = tagProperties.get ('command',None)
 		originalAtts = tagProperties.get ('originalAtts', None)

--- a/plasTeX/Renderers/__init__.py
+++ b/plasTeX/Renderers/__init__.py
@@ -351,8 +351,8 @@ class Renderer(dict):
     imageUnits = '&${units};'
     encodingErrors = 'replace'
 
-    def __init__(self, data={}):
-        dict.__init__(self, data)
+    def __init__(self, data=None):
+        dict.__init__(self, data or {})
 
         # Names of generated files
         self.files = {}

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -186,7 +186,7 @@ class TeX(object):
         options -- options passed to the macro which is loading the package
 
         """
-        options = options or None
+        options = options or {}
         config = self.ownerDocument.config
 
         try:

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -175,7 +175,7 @@ class TeX(object):
         if self.inputs:
             self.currentInput = self.inputs[-1]
 
-    def loadPackage(self, myfile, options={}):
+    def loadPackage(self, myfile, options=None):
         """
         Load a LaTeX package
 
@@ -186,6 +186,7 @@ class TeX(object):
         options -- options passed to the macro which is loading the package
 
         """
+        options = options or None
         config = self.ownerDocument.config
 
         try:


### PR DESCRIPTION
This is the python3 twin of #78 

Fixes #77. Remove mutable in function default values except in few cases where the
value is copied anyway. This is a twin of 28058f0d from the python2
branch