### PR TITLE
Fix indentation issue

### DIFF
--- a/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
+++ b/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py
@@ -841,7 +841,7 @@ class TemplateCompiler:
 					'singletonTag'    - A boolean to indicate that this is a singleton flag
 		"""
 		# Add the tag to the tagStack (list of tuples (tag, properties, useMacroLocation))
-                tagProperties = tagProperties or {}
+		tagProperties = tagProperties or {}
 		self.log.debug ("Adding tag %s to stack" % tag[0])
 		command = tagProperties.get('command', None)
 		originalAtts = tagProperties.get('originalAtts', None)


### PR DESCRIPTION
I'm sorry, there was indeed an indentation issue with #78 because [simpleTAL.py](https://github.com/tiarno/plastex/blob/master/plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py) contains tabs.

Now the crazy thing is: this issue was not found by tests in master branch but the python3 branch tests, which are meant to be the same, refused to run because of this!