### PR TITLE
HTML5 init typo and small test failure

### DIFF
--- a/plasTeX/Renderers/HTML5/__init__.py
+++ b/plasTeX/Renderers/HTML5/__init__.py
@@ -29,7 +29,6 @@ class HTML5(_Renderer):
         config = document.config
 
         rendererDir = os.path.dirname(__file__)
-        themeDir = os.path.join(rendererDir, 'Theme', self.loadedTheme)
 
         srcDir = document.userdata['working-dir']
         buildDir = os.getcwd()
@@ -61,7 +60,7 @@ class HTML5(_Renderer):
         if (config['html5']['use-theme-js'] and 
                 config['general']['copy-theme-extras']):
             rendererdata['js'] = sorted(
-                    os.listdir(os.path.join(themeDir, 'js')))
+                    os.listdir(os.path.join(self.loadedTheme, 'js')))
         else:
             rendererdata['js'] = []
 

--- a/unittests/PackageResources.py
+++ b/unittests/PackageResources.py
@@ -1,4 +1,5 @@
 import os
+import inspect
 from pytest import mark, fixture
 
 try:
@@ -110,9 +111,7 @@ def test_copy_missing_file(monkeypatch, doc):
     assert mock_logger.call_count == 1
 
 def test_rendererDir():
-    base = os.path.split(os.path.split(__file__)[0])[0]
-    path = os.path.join(base, 'plasTeX', 'Renderers', 'PageTemplate')
-    assert rendererDir(Renderer()) == path
+    assert rendererDir(Renderer()) == os.path.split(inspect.getfile(Renderer))[0]
 
 def test_package_template_dir_user_dir(monkeypatch, doc):
     renderer = Mock()


### PR DESCRIPTION
Mostly fixes a typo that had no consequence because ``PageTemplate.loadedTheme`` is already a full path.
Also fixes a test that worked using setuptools develop mode but not for a regular install.