### PR TITLE
Adds missing file plasTeXrc in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(name="plasTeX",
          'plasTeX.Renderers.S5.Themes.default.ui.default',
       ],
       package_data = {
-         'plasTeX': ['*.xml'],
+         'plasTeX': ['*.xml', 'plasTeXrc'],
          'plasTeX.Base.LaTeX': ['*.xml','*.txt'],
          'plasTeX.Renderers.DocBook': templates,
          'plasTeX.Renderers.DocBook.Themes.default': templates,


### PR DESCRIPTION
This file was forgotten forever, it has nothing to do with python3 or HTML5.