### PR TITLE
Python package for debugging purposes

### DIFF
--- a/plasTeX/Packages/debugplastex.py
+++ b/plasTeX/Packages/debugplastex.py
@@ -1,0 +1,35 @@
+import pdb
+
+from plasTeX import Command
+from plasTeX.Logging import getLogger
+
+
+class settrace(Command):
+    def invoke(self, tex):
+        document = self.ownerDocument
+        config = document.config
+        context = document.context
+        pdb.set_trace()
+
+
+class setloglevel(Command):
+    args = 'logger:str level:str'
+
+    def invoke(self, tex):
+        self.parse(tex)
+        logger_name = self.attributes['logger']
+        level = self.attributes['level']
+        logger = getLogger(logger_name)
+        logger.setLevel(level)
+
+        config = self.ownerDocument.config
+        config['logging'].data[logger_name].setValue(level)
+
+
+def ProcessOptions(options, document):
+    if 'post_parse_trace' in options:
+        def trace_callback():
+            config = document.config
+            context = document.context
+            pdb.set_trace()
+        document.postParseCallbacks.append(trace_callback)


### PR DESCRIPTION
This is a package that I've been using for a while. But discussions with the stacks project people convinced me I should share it. This package introduces a couple of commands for debugging purposes:
* a command to set logging levels like ``\setloglevel{parse.definitions}{DEBUG}`` (related to issue #93)
* a package argument ``\usepackage[post_parse_trace]{debugplastex}`` which drops into a debugger after parsing.
* a command ``\settrace`` to drop into a debugger during parsing.

I wanted to write documentation for this, but I couldn't decide which chapter to put it.
