### PR TITLE
imath and jmath are MathSymbols

### DIFF
--- a/plasTeX/Base/LaTeX/Math.py
+++ b/plasTeX/Base/LaTeX/Math.py
@@ -283,6 +283,9 @@ class chi(MathSymbol): str = chr(967)
 class psi(MathSymbol): str = chr(968)
 class omega(MathSymbol): str = chr(969)
 
+class imath(MathSymbol): str = chr(305)
+class jmath(MathSymbol): str = chr(567)
+
 # Uppercase
 class Gamma(MathSymbol): str = chr(915)
 class Delta(MathSymbol): str = chr(916)
@@ -295,7 +298,6 @@ class Upsilon(MathSymbol): str = chr(978)
 class Phi(MathSymbol): str = chr(934)
 class Psi(MathSymbol): str = chr(936)
 class Omega(MathSymbol): str = chr(8486)
-
 
 #
 # Table 3.4: Binary Operation Symbols
@@ -645,8 +647,6 @@ class ddot(MathAccent): pass
 
 class widehat(MathAccent): pass
 class widetilde(MathAccent): pass
-class imath(MathAccent): pass
-class jmath(MathAccent): pass
 class stackrel(MathAccent):
     args = 'top bottom'
 

--- a/unittests/Packages/Amsmath.py
+++ b/unittests/Packages/Amsmath.py
@@ -1,6 +1,6 @@
 from plasTeX.TeX import TeX
 
-DOC = r"""
+DOC_numberwithin = r"""
 \documentclass{article}
 \usepackage{amsmath}
 \numberwithin{equation}{section}
@@ -22,9 +22,32 @@ e = f
 
 def test_numberwithin():
     s = TeX()
-    s.input(DOC)
+    s.input(DOC_numberwithin)
     output = s.parse()
     equations =output.getElementsByTagName('equation')
     assert equations[0].ref.textContent == '1.1'
     assert equations[1].ref.textContent == '2.1'
     assert equations[2].ref.textContent == '2.2'
+
+DOC_imath = r"""
+\documentclass{article}
+
+\begin{document}
+
+$\imath$ $\jmath$
+
+\end{document}
+"""
+
+def test_imath():
+    s = TeX()
+    s.input(DOC_imath)
+    output = s.parse()
+
+    imath = output.getElementsByTagName('imath')[0]
+    assert len(imath.childNodes) == 0
+    assert imath.str == chr(305)
+    jmath = output.getElementsByTagName('jmath')[0]
+
+    assert len(jmath.childNodes) == 0
+    assert jmath.str == chr(567)


### PR DESCRIPTION
\imath and \jmath were defined as MathAccents, which meant they required an argument. In fact, they're just symbols and don't take an argument.