### PR TITLE
tox tested minimal changes to support Plastex issue 360

### DIFF
--- a/plasTeX/Compile.py
+++ b/plasTeX/Compile.py
@@ -46,7 +46,7 @@ def load_renderer(rname: str, config: ConfigManager) -> Renderer:
             return getattr(importlib.import_module(plugin + '.Renderers.' + rname),
                            'Renderer')()
         except ImportError:
-            pluginlog.info(f"Loading renderer[{rname}]: "+traceback.format_exc(limit=-1))
+            pluginlog.debug(f"Loading renderer[{rname}]: "+traceback.format_exc(limit=-1))
 
     try:
         return getattr(import_file(Path(rname)), 'Renderer')()

--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -458,7 +458,7 @@ class Context(object):
                     imported = import_module(plugin + '.Packages.' + module)
                     break
                 except (ImportError, ModuleNotFoundError) as msg:
-                    pluginlog.info(f"Importing package[{module}]: "+traceback.format_exc(limit=-1))
+                    pluginlog.debug(f"Importing package[{module}]: "+traceback.format_exc(limit=-1))
                     # No Python module
                     if 'No module' in str(msg) and module in str(msg):
                         pass


### PR DESCRIPTION
This PR adds the ability to log plugin loading errors to a new `plugin.loading` logger.

This PR provides a potential solution to the PlasTeX issue #360.

There are two files which load external plastex plugins via the `config['general']['plugins']` MultiStringOption (list of strings):

1. **`Compile.py` has been altered** to `getLogger('plugin.loading')` and use this `pluginlog` to report `ImportError` (instead of silently ignoring these errors).
2. **`Context.py` has been altered** to `getLogger('plugin.loading')` and use this `pluginlog` to report `ImportError` and `ModuleNotFoundError` (instead of silently ignoring these errors).

In both cases these errors are logged at the `INFO` level so that normally they are not seen by the user.

However if the plugin developer uses the `--logging plugin.loading INFO` PlasTeX command line option, these errors will be reported.

In both cases the last (most recent) line of the error traceback is also reported to the plugin developer, helping to pin point the errors in the plugin code.

This behaviour can be used by PlasTeX plugin developers to understand why their code might not be being loaded.

With the current behaviour, any loading errors in the plugin's code are silently ignored, which is not helpful to plugin developers.

---

**Testing using existing PlasTeX tests:**

As with PR #359, this PR has been tested (as the `plastex_issue_360` branch) using Tox using the [diSimplex/plastex-tox](https://github.com/diSimplex/plastex-tox) tool.

Again as mentioned in PR #359, the only errors encountered are identical to those found by this `plastex-tox` tool in the `master` branch of the existing PlasTeX repository, hence I conclude this new code has not broken any existing tests.