### PR TITLE
Fix issue 316:  hyperref in HTML5 produces invalid internal links

### DIFF
--- a/plasTeX/Renderers/HTML5/hyperref.jinja2s
+++ b/plasTeX/Renderers/HTML5/hyperref.jinja2s
@@ -16,7 +16,7 @@ name: hyperdef
 <a name="{{ obj.attributes.category }}.{{ obj.attributes.name }}" >{{ obj }}</a>
 
 name: hyperref
-<a href="{{ obj.attributes.url }}#{{ obj.attributes.category }}.{{ obj.attributes.name}}" >{{ obj }}</a>
+<a href="{% if obj.idref %}{{ obj.idref.label.url }}{% else %}{{ obj.attributes.url }}#{{ obj.attributes.category }}.{{ obj.attributes.name}}{% endif %}" >{{ obj }}</a>
 
 name: hyperlink
 <a href="{{ obj.idref.label.url }}" >{{ obj }}</a>

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -563,7 +563,7 @@ class Macro(Element):
         tex -- the TeX instance containing the current context
 
         """
-        if self.counter:
+        if self.counter is not None:
             self.ownerDocument.context.currentlabel = self
             self.stepcounter(tex)
 

--- a/unittests/Crossref.py
+++ b/unittests/Crossref.py
@@ -21,8 +21,8 @@ class Labels(TestCase):
         output = s.parse()
         one = output[0]
         two = output[-1]
-        assert one.id == 'two', one.id
-        assert two.id != 'two', two.id
+        assert one.id != 'two', one.id
+        assert two.id == 'two', two.id
 
 
 if __name__ == '__main__':

--- a/unittests/Packages/hyperref.py
+++ b/unittests/Packages/hyperref.py
@@ -1,4 +1,9 @@
-from plasTeX.TeX import TeX
+from pathlib import Path
+
+from plasTeX.TeX import TeX, TeXDocument
+from plasTeX.Config import defaultConfig
+from plasTeX.Renderers.HTML5 import Renderer
+from plasTeX.Renderers.HTML5.Config import addConfig
 
 def test_href_no_char_sub():
     """Test for issue #342"""
@@ -18,3 +23,44 @@ def test_href_no_char_sub():
     assert len(hrefs) == 1
     assert hrefs[0].attributes['url'].textContent == 'a--file.pdf'
 
+def test_hyperref_html5(tmpdir):
+    """ Test for issue #316 """
+
+    root = Path(__file__).parent
+    config = defaultConfig()
+    addConfig(config)
+    config['files']['split-level'] = -100
+    tex = TeX(TeXDocument(config=config))
+    tex.input(r"""
+\documentclass{article}
+\usepackage{hyperref}
+
+\begin{document}
+A link to:
+
+\hyperref[numbered]{numbered section}
+
+\hyperref[not-numbered]{not numbered section}
+
+\section{Numbered}\label{numbered}
+
+This section is numbered.
+
+\section*{Not numbered}\label{not-numbered}
+
+This section is not numbered.
+
+\end{document}
+    """)
+    doc = tex.parse()
+    doc.userdata['working-dir'] = Path(__file__).parent
+
+    with tmpdir.as_cwd():
+            Renderer().render(doc)
+
+    assert (Path(tmpdir)/'index.html').exists()
+
+    html = (Path(tmpdir)/'index.html').read_text()
+
+    assert '<a href="index.html#numbered" >numbered section</a>' in html
+    assert '<a href="index.html#not-numbered" >not numbered section</a>' in html


### PR DESCRIPTION
This fixes #316.

There are fixes for two problems in this PR, because I noticed them at the same time and they're related.

The first is the one mentioned in the linked issue, that the HTML 5 renderer doesn't make the right `href` attribute for the `\hyperref[ref]{text}` command.

The second is that starred sectioning elements like `\section*` should take labels. There was an existing unit test asserting that this is not the case, but I think this is incorrect: pdflatex will assign labels to starred sections. My fix is a bit awkward: since the `counter` attribute on starred elements is set to the empty string, I've changed `refstepcounter` to check that counter is not `None`, so that starred elements do take labels, but `stepcounter` still just checks that `counter` is truthy, so they don't increment the counter.