### PR TITLE
Tag amsmath equation environments

### DIFF
--- a/plasTeX/Base/LaTeX/Math.py
+++ b/plasTeX/Base/LaTeX/Math.py
@@ -149,7 +149,7 @@ class ensuremath(Command):
             return mathjax_lt_gt(sourceChildren(self))
         return ""
 
-class equation(MathEnvironment):
+class equation(MathEnvironmentPre):
     blockType = True
     counter = 'equation'
 

--- a/plasTeX/Base/LaTeX/Math.py
+++ b/plasTeX/Base/LaTeX/Math.py
@@ -5,7 +5,7 @@ C.7 Mathematical Formulas (p187)
 
 from plasTeX.Base.LaTeX.Arrays import Array
 from plasTeX import Command, Environment, sourceChildren, NoCharSubEnvironment
-from plasTeX import DimenCommand, GlueCommand, TeXFragment
+from plasTeX import DimenCommand, GlueCommand, TeXFragment, sourceArguments
 from typing import Optional
 
 #

--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -173,6 +173,9 @@ class Context(object):
         # Object that the current label points to
         self.currentlabel = None
 
+        # The current equation environment
+        self.currentequation = None
+
         # Labeled objects
         self.labels = {}
         self.persistentLabels = {}

--- a/plasTeX/Packages/amsmath.py
+++ b/plasTeX/Packages/amsmath.py
@@ -1,4 +1,4 @@
-from plasTeX import Command
+from plasTeX import Command, Macro, NewCommand, TeXFragment
 from plasTeX.Base.LaTeX.Arrays import Array
 from plasTeX.Base.LaTeX.Math import EqnarrayStar, eqnarray
 #### Imports Added by Tim ####
@@ -8,6 +8,10 @@ from plasTeX import Tokenizer
 from plasTeX.Logging import getLogger
 
 deflog = getLogger('parse.definitions')
+
+def ProcessOptions(options, document):  # type: ignore
+    context = document.context
+    context.newcounter('parentequation')
 
 class pmatrix(Array):
     pass
@@ -75,8 +79,54 @@ class flalign(_AMSEquation):
 class FlalignStar(_AMSEquationStar):
     macroName = 'flalign*'
 
+class tag(Command):
+    args = 'tag:str'
+
+    @property
+    def source(self):
+        return ''
+
+    def invoke(self, tex):
+        Command.invoke(self, tex)
+        node = self.ownerDocument.context.currentequation
+        self.ownerDocument.context.counters['equation'].value -= 1
+        if node:
+            node.equation_tag = self.attributes['tag']
+            node.ref = self.ownerDocument.createTextNode(node.equation_tag)
+
 class subequations(_AMSEquation):
-    pass
+    counter = 'parentequation'
+    
+    def invoke(self, tex):
+        if self.macroMode == Macro.MODE_END:
+            context = self.ownerDocument.context
+
+            equation = context.counters['equation']
+            parentequation = context.counters['parentequation']
+
+            equation.value = parentequation.value
+
+        return super().invoke(tex)
+
+    def parse(self, tex):
+        if self.macroMode == Macro.MODE_BEGIN:
+            context = self.ownerDocument.context
+
+            equation = context.counters['equation']
+            parentequation = context.counters['parentequation']
+
+            parentequation.value = equation.value
+            equation.value = 0
+
+            definition = list(Tokenizer.Tokenizer(r'\theparentequation \alph{equation}', context))
+
+            context.top['theequation'] = type(
+                'theequation', 
+                (NewCommand,),
+                {'nargs': 0, 'opt': None, 'definition': definition}
+            )
+
+        return super().parse(tex)
 
 class xalignat(alignat):
     pass

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -346,7 +346,7 @@ class Macro(Element):
     def equation_tag(self):
         tag = getattr(self, '@equation_tag', None)
         if tag is None:
-            return self.ref
+            return self.ref.textContent if self.ref is not None else None
         return tag
 
     @equation_tag.setter

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -342,6 +342,20 @@ class Macro(Element):
         else:
             delattr(self, '@id')
 
+    @property
+    def equation_tag(self):
+        tag = getattr(self, '@equation_tag', None)
+        if tag is None:
+            return self.ref
+        return tag
+
+    @equation_tag.setter
+    def equation_tag(self, value):
+        if value:
+            setattr(self, '@equation_tag', value)
+        else:
+            delattr(self, '@equation_tag')
+
     def expand(self, tex):
         """ Fully expand the macro """
         result = self.invoke(tex)

--- a/unittests/Packages/Amsmath.py
+++ b/unittests/Packages/Amsmath.py
@@ -24,7 +24,7 @@ def test_numberwithin():
     s = TeX()
     s.input(DOC_numberwithin)
     output = s.parse()
-    equations =output.getElementsByTagName('equation')
+    equations = output.getElementsByTagName('equation')
     assert equations[0].ref.textContent == '1.1'
     assert equations[1].ref.textContent == '2.1'
     assert equations[2].ref.textContent == '2.2'
@@ -83,3 +83,83 @@ def test_split():
 
     assert equations[0].ref.textContent == '1'
     assert equations[1].ref.textContent == '2'
+
+DOC_subequations = r"""
+\documentclass{article}
+
+\usepackage{amsmath}
+
+\begin{document}
+
+Subequations
+
+\begin{subequations}\label{s1}
+\begin{equation}
+x = 1 \label{e1a}
+\end{equation}
+\begin{equation}
+y = 2\label{e1b}
+\end{equation}
+\end{subequations}
+
+Equation with no tag
+
+\begin{equation}\label{e2}
+c = c
+\end{equation}
+
+Equation with tag
+
+\begin{equation}\label{ez}
+ a = f \tag{z}
+\end{equation}
+
+Subequations again
+
+\begin{subequations}\label{s2}
+    \begin{equation}
+    x = 1\label{e2a}
+    \end{equation}
+    \begin{equation}
+    y = 2\tag{y}\label{e2y}
+    \end{equation}
+    \begin{equation}
+    y = 3\label{e2b}
+    \end{equation}
+\end{subequations}
+
+Refs: \ref{s1} \ref{e1a} \ref{e1b} \ref{e2} \ref{ez} \ref{s2} \ref{e2a} \ref{e2y} \ref{e2b}
+
+\end{document}
+"""
+
+def test_subequations():
+    s = TeX()
+    s.input(DOC_subequations)
+    output = s.parse()
+
+    equations = output.getElementsByTagName('equation')
+    print(equations)
+
+    equation_refs = [
+        '1a',
+        '1b',
+        '2',
+        'z',
+        '3a',
+        'y',
+        '3b',
+    ]
+
+    for i, ref in enumerate(equation_refs):
+        assert equations[i].ref.textContent == ref
+
+    subequations = output.getElementsByTagName('subequations')
+
+    subequations_refs = [
+        '1',
+        '3',
+    ]
+
+    for i, ref in enumerate(subequations_refs):
+        assert subequations[i].ref.textContent == ref

--- a/unittests/Packages/Amsmath.py
+++ b/unittests/Packages/Amsmath.py
@@ -128,6 +128,10 @@ Subequations again
     \end{equation}
 \end{subequations}
 
+\begin{equation*}
+b
+\end{equation*}
+
 Refs: \ref{s1} \ref{e1a} \ref{e1b} \ref{e2} \ref{ez} \ref{s2} \ref{e3a} \ref{e3y} \ref{e3b}
 
 \end{document}
@@ -163,3 +167,9 @@ def test_subequations():
     for i, (ref, source) in enumerate(subequations_refs):
         assert subequations[i].source == source
         assert subequations[i].ref.textContent == ref
+
+
+    starred_equations = output.getElementsByTagName('equation*')
+    assert len(starred_equations) == 1
+    assert starred_equations[0].source == r'\begin{equation*}  b \end{equation*}'
+    assert starred_equations[0].ref is None

--- a/unittests/Packages/Amsmath.py
+++ b/unittests/Packages/Amsmath.py
@@ -118,17 +118,17 @@ Subequations again
 
 \begin{subequations}\label{s2}
     \begin{equation}
-    x = 1\label{e2a}
+    x = 1\label{e3a}
     \end{equation}
     \begin{equation}
-    y = 2\tag{y}\label{e2y}
+    y = 2\tag{y}\label{e3y}
     \end{equation}
     \begin{equation}
-    y = 3\label{e2b}
+    y = 3\label{e3b}
     \end{equation}
 \end{subequations}
 
-Refs: \ref{s1} \ref{e1a} \ref{e1b} \ref{e2} \ref{ez} \ref{s2} \ref{e2a} \ref{e2y} \ref{e2b}
+Refs: \ref{s1} \ref{e1a} \ref{e1b} \ref{e2} \ref{ez} \ref{s2} \ref{e3a} \ref{e3y} \ref{e3b}
 
 \end{document}
 """
@@ -139,7 +139,6 @@ def test_subequations():
     output = s.parse()
 
     equations = output.getElementsByTagName('equation')
-    print(equations)
 
     equation_refs = [
         '1a',
@@ -157,9 +156,10 @@ def test_subequations():
     subequations = output.getElementsByTagName('subequations')
 
     subequations_refs = [
-        '1',
-        '3',
+        ('1', r'\begin{subequations} \label{s1} \begin{equation}x = 1 \label{e1a}\tag{1a}\end{equation}\begin{equation}y = 2\label{e1b}\tag{1b}\end{equation}\end{subequations}'),
+        ('3', r'\begin{subequations} \label{s2} \begin{equation}x = 1\label{e3a}\tag{3a}\end{equation}\begin{equation}y = 2\label{e3y}\tag{y}\end{equation}\begin{equation}y = 3\label{e3b}\tag{3b}\end{equation}\end{subequations}'),
     ]
 
-    for i, ref in enumerate(subequations_refs):
+    for i, (ref, source) in enumerate(subequations_refs):
+        assert subequations[i].source == source
         assert subequations[i].ref.textContent == ref

--- a/unittests/benchmarks/equations.html
+++ b/unittests/benchmarks/equations.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  MathJax = { 
+    tex: {
+		    inlineMath: [['\\(','\\)']]
+	} }
+</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+<meta name="generator" content="plasTeX" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+<p> inline: \(x\) </p>
+<p>Display mode: </p>
+<div class="displaymath" id="a0000000002">
+  \[  y  \]
+</div>
+<p>Equation: </p>
+<div class="equation" id="a0000000003">
+<p>
+  <div class="equation_content">
+    \begin{equation}x\tag{1}\end{equation}
+  </div>
+  <span class="equation_label">1</span>
+</p>
+</div>
+<p>Unlabelled equation: </p>
+<div class="displaymath" id="a0000000004">
+  \begin{equation*}  x \end{equation*}
+</div>
+<p>Gathered in the center: </p>
+<div class="displaymath" id="a0000000005">
+  \begin{gather}  x \\ y \end{gather}
+</div>
+<p>Aligned: </p>
+<div class="displaymath" id="a0000000006">
+  \begin{align}  a & = 1 \\ b & = 2 \end{align}
+</div>
+<p>Unlabelled align: </p>
+<div class="displaymath" id="a0000000007">
+  \begin{align*}  a & = 1 \\ b & = 2 \end{align*}
+</div>
+<p>Equation array: </p>
+<div class="displaymath" id="a0000000008">
+  \begin{eqnarray}  a & =&  1 \\ b & =&  2 \end{eqnarray}
+</div>
+<p>Subequations: </p>
+<div class="equation" id="a0000000009">
+<p>
+  <div class="equation_content">
+    \begin{equation}x\tag{8a}\end{equation}
+  </div>
+  <span class="equation_label">8a</span>
+</p>
+</div>
+
+
+</body>
+</html><!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  MathJax = { 
+    tex: {
+		    inlineMath: [['\\(','\\)']],
+	} }
+</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+<meta name="generator" content="plasTeX" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+<p> inline: \(x\) </p>
+<p>Display mode: </p>
+<div class="displaymath" id="a0000000002">
+  \[  y  \]
+</div>
+<p>Equation: </p>
+<div class="equation" id="a0000000003">
+<p>
+  <div class="equation_content">
+    \begin{equation}x\tag{1}\end{equation}
+  </div>
+  <span class="equation_label">1</span>
+</p>
+</div>
+<p>Unlabelled equation: </p>
+<div class="displaymath" id="a0000000004">
+  \begin{equation*}  x \end{equation*}
+</div>
+<p>Gathered in the center: </p>
+<div class="displaymath" id="a0000000005">
+  \begin{gather}  x \\ y \end{gather}
+</div>
+<p>Aligned: </p>
+<div class="displaymath" id="a0000000006">
+  \begin{align}  a & = 1 \\ b & = 2 \end{align}
+</div>
+<p>Unlabelled align: </p>
+<div class="displaymath" id="a0000000007">
+  \begin{align*}  a & = 1 \\ b & = 2 \end{align*}
+</div>
+<p>Equation array: </p>
+<div class="displaymath" id="a0000000008">
+  \begin{eqnarray}  a & =&  1 \\ b & =&  2 \end{eqnarray}
+</div>
+<p>Subequations: </p>
+<div class="equation" id="a0000000009">
+<p>
+  <div class="equation_content">
+    \begin{equation}x\tag{8a}\end{equation}
+  </div>
+  <span class="equation_label">8a</span>
+</p>
+</div>
+
+
+</body>
+</html>

--- a/unittests/sources/equations.tex
+++ b/unittests/sources/equations.tex
@@ -1,0 +1,47 @@
+\documentclass{article}
+\usepackage{amsmath}
+\begin{document}
+    inline: $x$
+
+    Display mode:
+    \[ y \]
+
+    Equation:
+    \begin{equation}
+        x
+    \end{equation}
+
+    Unlabelled equation:
+    \begin{equation*}
+        x
+    \end{equation*}
+
+    Gathered in the center:
+    \begin{gather}
+        x \\
+        y
+    \end{gather}
+
+    Aligned:
+    \begin{align}
+        a &= 1 \\
+        b &= 2
+    \end{align}
+
+    Unlabelled align:
+    \begin{align*}
+        a &= 1 \\
+        b &= 2
+    \end{align*}
+
+    Equation array:
+    \begin{eqnarray}
+        a &=& 1 \\
+        b &=& 2
+    \end{eqnarray}
+
+    Subequations:
+    \begin{subequations}
+        \begin{equation} x \end{equation}
+    \end{subequations}
+\end{document}


### PR DESCRIPTION
Fixes #365 

This adds an `currentequation` property to the Context object which stores the last seen equation environment.

The `\tag` command sets the `equation_tag` property of the current equation to its argument.

When getting the source of a MathEnvironment, a \tag command is included, using either the `equation_tag`, or the element's `ref` property, which will correspond to the numbering from the `equation` counter, or `parentequation` and `equation` in a subequations environment.

This doesn't deal with nested subequations environments. I was unsure how to redefine the `theparentequation` command to do this, but hopefully someone who knows the internals of plasTeX better will be able to sort it out.
I think that `\theparentequation` should expand to whatever `theequation` did at the start of the subequations environment, instead of using the default definition which looks at the `parentequation` counter.