### PR TITLE
Add support for custom item labels to enumerate

### DIFF
--- a/plasTeX/Packages/beamer.py
+++ b/plasTeX/Packages/beamer.py
@@ -1,8 +1,9 @@
 from plasTeX import Command, Environment
+import plasTeX.Base
 from plasTeX.Base import textbf, textit, textsl, textrm, textsf
 from plasTeX.Base import List, label, newcommand, newenvironment
 from plasTeX.Base import renewcommand, renewenvironment
-from plasTeX.Base import itemize, enumerate_, description
+from plasTeX.Base import itemize, description
 from plasTeX.Base import part, section, subsection, subsubsection
 from plasTeX.Base import tableofcontents, thebibliography
 from plasTeX.Base import abstract, verse, quotation, quote, footnote, footnotetext
@@ -152,7 +153,10 @@ renewcommand.args = '< overlay >' + renewcommand.args
 newenvironment.args = '< overlay >' + newenvironment.args
 renewenvironment.args = '< overlay >' + renewenvironment.args
 itemize.args = '[ overlay ]'
-enumerate_.args = '[ overlay ] [ template ]'
+
+class enumerate_(plasTeX.Base.enumerate_):
+    args = '[ overlay ] [ template ]'
+
 description.args = '[ overlay ] [ longtext ]'
 section.args = '< overlay >' + section.args
 subsection.args = '< overlay >' + subsection.args

--- a/plasTeX/Renderers/HTML5/Lists.jinja2s
+++ b/plasTeX/Renderers/HTML5/Lists.jinja2s
@@ -1,16 +1,46 @@
 name: itemize
-<ul class="itemize">
-{% for item in obj %}
-  <li>{{ item }}</li>
-{% endfor %}
-</ul>
+{% if obj.has_custom_terms %}
+    <ul id="{{ obj.id }}" class="itemize custom-terms">
+    {% for item in obj %}
+        <li id="{{ item.id }}">
+            {% if item.attributes.term %}<div class="list-item-marker">{{item.attributes.term}}</div>{% else %}<div class="list-item-marker default-marker"></div>{% endif %}
+            <div class="list-item-content">
+                {{ item }}
+            </div>
+        </li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <ul id="{{ obj.id }}" class="itemize">
+    {% for item in obj %}
+        <li id="{{ item.id }}">
+            {{ item }}
+        </li>
+    {% endfor %}
+    </ul>
+{% endif %}
 
 name: enumerate
-<ol class="enumerate">
-{% for item in obj %}
-  <li>{{ item }}</li>
-{% endfor %}
-</ol>
+{% if obj.has_custom_terms %}
+    <ol id="{{ obj.id }}" class="enumerate custom-terms">
+    {% for item in obj %}
+        <li id="{{ item.id }}" value="{{item.position}}">
+            {% if item.attributes.term %}<div class="list-item-marker">{{item.attributes.term}}</div>{% else %}<div class="list-item-marker default-marker">{{obj.term(item.position)}}</div>{% endif %}
+            <div class="list-item-content">
+                {{ item }}
+            </div>
+        </li>
+    {% endfor %}
+    </ol>
+{% else %}
+    <ol id="{{ obj.id }}" class="enumerate">
+    {% for item in obj %}
+        <li id="{{ item.id }}" value="{{item.position}}">
+            {{ item }}
+        </li>
+    {% endfor %}
+    </ol>
+{% endif %}
 
 name: list trivlist description
 <dl class="{{ obj.nodeName }}">

--- a/plasTeX/Renderers/HTML5/Lists.jinja2s
+++ b/plasTeX/Renderers/HTML5/Lists.jinja2s
@@ -3,7 +3,7 @@ name: itemize
     <ul id="{{ obj.id }}" class="itemize custom-terms">
     {% for item in obj %}
         <li id="{{ item.id }}">
-            {% if item.attributes.term %}<div class="list-item-marker">{{item.attributes.term}}</div>{% else %}<div class="list-item-marker default-marker"></div>{% endif %}
+            {% if item.attributes.term %}<div class="list-item-marker">{{item.attributes.term|e}}</div>{% else %}<div class="list-item-marker default-marker"></div>{% endif %}
             <div class="list-item-content">
                 {{ item }}
             </div>
@@ -25,7 +25,7 @@ name: enumerate
     <ol id="{{ obj.id }}" class="enumerate custom-terms">
     {% for item in obj %}
         <li id="{{ item.id }}" value="{{item.position}}">
-            {% if item.attributes.term %}<div class="list-item-marker">{{item.attributes.term}}</div>{% else %}<div class="list-item-marker default-marker">{{obj.term(item.position)}}</div>{% endif %}
+            {% if item.attributes.term %}<div class="list-item-marker">{{item.attributes.term|e}}</div>{% else %}<div class="list-item-marker default-marker">{{obj.term(item.position)|e}}</div>{% endif %}
             <div class="list-item-content">
                 {{ item }}
             </div>

--- a/plasTeX/encoding.py
+++ b/plasTeX/encoding.py
@@ -2,3 +2,56 @@ import string
 
 def stringletters():
     return string.ascii_letters
+
+def numToRoman(x: int) -> str:
+    """ Represent the given positive integer in roman numerals. """
+
+    numerals = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+
+    s = ""
+    for n, t in numerals:
+        k, r = divmod(x, n)
+        s += t*k
+        x -= n*k
+
+    return s
+
+def numToAlpha(i):
+    """ Represent the given positive integer in letters.
+        e.g. 1 → 'a'
+             26 → 'aa'
+             27 → 'ab'
+    """
+
+    i -= 1
+
+    l = 26
+    alphabet = string.ascii_letters[:l]
+    digits = 1
+    
+    while i >= l**digits:
+        i -= l**digits
+        digits += 1
+
+    s = ''
+
+    for n in range(digits):
+        r = i % l
+        s = alphabet[r] + s
+        i = (i - r) // l
+
+    return s

--- a/unittests/Packages/benchmarks/bib.html
+++ b/unittests/Packages/benchmarks/bib.html
@@ -15,30 +15,37 @@
 </head>
 
 <body>
-<ol class="enumerate">
-  <li><p><code class="verbatim">\cite{goossens:companion}</code> — <span class="cite">
+    <ol id="a0000000002" class="enumerate">
+        <li id="a0000000003" value="1">
+            <p><code class="verbatim">\cite{goossens:companion}</code> — <span class="cite">
 	[
 	<a href="bib.html#goossens:companion" >2</a>
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000004" value="2">
+            <p><code class="verbatim">\cite{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	<a href="bib.html#goossens:companion" >2</a>
 	, 
 	<a href="bib.html#hagen:metafun" >1</a>
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000005" value="3">
+            <p><code class="verbatim">\cite[page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	<a href="bib.html#goossens:companion" >2</a>
 	, 
 	page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000006" value="4">
+            <p><code class="verbatim">\cite[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	<a href="bib.html#goossens:companion" >2</a>
 	, 
@@ -47,8 +54,10 @@
 	page 99ff
 	]
 </span> </p>
-</li>
-</ol>
+
+        </li>
+    </ol>
+
 <div class="bibliography">
 <h1>Bibliography</h1>
 <dl class="bibliography">

--- a/unittests/Packages/benchmarks/multibib.html
+++ b/unittests/Packages/benchmarks/multibib.html
@@ -16,8 +16,9 @@
 
 <body>
 <p><b class="bfseries">Multiple References</b> </p>
-<ol class="enumerate">
-  <li><p><code class="verbatim">\citet[see][]{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
+    <ol id="a0000000002" class="enumerate">
+        <li id="a0000000003" value="1">
+            <p><code class="verbatim">\citet[see][]{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	[
@@ -35,8 +36,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citep{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000004" value="2">
+            <p><code class="verbatim">\citep{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
 	[
 	
 	von Goossens et&#160;al.
@@ -51,8 +54,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt[see][]{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000005" value="3">
+            <p><code class="verbatim">\citealt[see][]{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	see 
@@ -66,8 +71,10 @@
 	<a href="multibib.html#hagen:metafun" >2000</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp[see][]{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000006" value="4">
+            <p><code class="verbatim">\citealp[see][]{goossens:companion,goossens:companion2,hagen:metafun}</code> — <span class="cite">
 	see 
 	von Goossens et&#160;al.
 	, 
@@ -80,8 +87,10 @@
 	<a href="multibib.html#hagen:metafun" >2000</a>
 	
 </span> </p>
-</li>
-</ol>
+
+        </li>
+    </ol>
+
 <div class="bibliography">
 <h1>Bibliography</h1>
 <dl class="bibliography">

--- a/unittests/Packages/benchmarks/natbib.html
+++ b/unittests/Packages/benchmarks/natbib.html
@@ -18,8 +18,9 @@
 <body>
 
 <p><b class="bfseries">No prenote, No postnote</b> </p>
-<ol class="enumerate">
-  <li><p><code class="verbatim">\cite{goossens:companion}</code> — <span class="cite">
+    <ol id="a0000000002" class="enumerate">
+        <li id="a0000000003" value="1">
+            <p><code class="verbatim">\cite{goossens:companion}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	[
@@ -28,8 +29,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite*{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000004" value="2">
+            <p><code class="verbatim">\cite*{goossens:companion}</code> — <span class="cite">
 	von Goossens, Rahtz, and Mittelbach
 	 
 	[
@@ -38,62 +41,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	]
-	, 
-	Hagen
-	 
-	[
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\cite*{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	]
-	, 
-	Hagen
-	 
-	[
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet{goossens:companion}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet*{goossens:companion}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000005" value="3">
+            <p><code class="verbatim">\cite{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	[
@@ -109,8 +60,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citet*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000006" value="4">
+            <p><code class="verbatim">\cite*{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	von Goossens, Rahtz, and Mittelbach
 	 
 	[
@@ -126,8 +79,72 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citep{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000007" value="5">
+            <p><code class="verbatim">\citet{goossens:companion}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000008" value="6">
+            <p><code class="verbatim">\citet*{goossens:companion}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000009" value="7">
+            <p><code class="verbatim">\citet{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	]
+	, 
+	Hagen
+	 
+	[
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000010" value="8">
+            <p><code class="verbatim">\citet*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	]
+	, 
+	Hagen
+	 
+	[
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000011" value="9">
+            <p><code class="verbatim">\citep{goossens:companion}</code> — <span class="cite">
 	[
 	
 	von Goossens et&#160;al.
@@ -136,8 +153,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citep*{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000012" value="10">
+            <p><code class="verbatim">\citep*{goossens:companion}</code> — <span class="cite">
 	[
 	
 	von Goossens, Rahtz, and Mittelbach
@@ -146,94 +165,11 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citep{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000013" value="11">
+            <p><code class="verbatim">\citep{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
-	
-	von Goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep*{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	
-	von Goossens, Rahtz, and Mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt{goossens:companion}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt*{goossens:companion}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt*{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp{hagen:metafun}</code> — <span class="cite">
-	
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp*{hagen:metafun}</code> — <span class="cite">
-	
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	von Goossens et&#160;al.
 	, 
@@ -243,9 +179,112 @@
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
+	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000014" value="12">
+            <p><code class="verbatim">\citep*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	
+	von Goossens, Rahtz, and Mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000015" value="13">
+            <p><code class="verbatim">\citealt{goossens:companion}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000016" value="14">
+            <p><code class="verbatim">\citealt*{goossens:companion}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000017" value="15">
+            <p><code class="verbatim">\citealt{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000018" value="16">
+            <p><code class="verbatim">\citealt*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000019" value="17">
+            <p><code class="verbatim">\citealp{hagen:metafun}</code> — <span class="cite">
+	
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000020" value="18">
+            <p><code class="verbatim">\citealp*{hagen:metafun}</code> — <span class="cite">
+	
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000021" value="19">
+            <p><code class="verbatim">\citealp{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	
+	von Goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000022" value="20">
+            <p><code class="verbatim">\citealp*{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	von Goossens, Rahtz, and Mittelbach
 	, 
@@ -256,64 +295,84 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000023" value="21">
+            <p><code class="verbatim">\citeauthor{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor*{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000024" value="22">
+            <p><code class="verbatim">\citeauthor*{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citefullauthor{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000025" value="23">
+            <p><code class="verbatim">\citefullauthor{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000026" value="24">
+            <p><code class="verbatim">\citeauthor{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens et&#160;al.</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000027" value="25">
+            <p><code class="verbatim">\citeauthor*{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens, Rahtz, and Mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citefullauthor{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000028" value="26">
+            <p><code class="verbatim">\citefullauthor{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens, Rahtz, and Mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyear{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000029" value="27">
+            <p><code class="verbatim">\citeyear{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyear{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000030" value="28">
+            <p><code class="verbatim">\citeyear{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyearpar{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000031" value="29">
+            <p><code class="verbatim">\citeyearpar{hagen:metafun}</code> — <span class="cite">
 	[
 	
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyearpar{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000032" value="30">
+            <p><code class="verbatim">\citeyearpar{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	
 	<a href="natbib.html#goossens:companion" >1997</a>
@@ -322,8 +381,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000033" value="31">
+            <p><code class="verbatim">\Citet{goossens:companion}</code> — <span class="cite">
 	Von goossens et&#160;al.
 	 
 	[
@@ -332,8 +393,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet*{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000034" value="32">
+            <p><code class="verbatim">\Citet*{goossens:companion}</code> — <span class="cite">
 	Von goossens, rahtz, and mittelbach
 	 
 	[
@@ -342,8 +405,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000035" value="33">
+            <p><code class="verbatim">\Citet{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	Von goossens et&#160;al.
 	 
 	[
@@ -359,8 +424,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000036" value="34">
+            <p><code class="verbatim">\Citet*{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	Von goossens, rahtz, and mittelbach
 	 
 	[
@@ -376,8 +443,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000037" value="35">
+            <p><code class="verbatim">\Citep{goossens:companion}</code> — <span class="cite">
 	[
 	
 	Von goossens et&#160;al.
@@ -386,8 +455,10 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep*{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000038" value="36">
+            <p><code class="verbatim">\Citep*{goossens:companion}</code> — <span class="cite">
 	[
 	
 	Von goossens, rahtz, and mittelbach
@@ -396,94 +467,11 @@
 	
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000039" value="37">
+            <p><code class="verbatim">\Citep{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
-	
-	Von goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep*{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	
-	Von goossens, rahtz, and mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt{goossens:companion}</code> — <span class="cite">
-	Von goossens et&#160;al.
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt*{goossens:companion}</code> — <span class="cite">
-	Von goossens, rahtz, and mittelbach
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	Von goossens et&#160;al.
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt*{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	Von goossens, rahtz, and mittelbach
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp{hagen:metafun}</code> — <span class="cite">
-	
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp*{hagen:metafun}</code> — <span class="cite">
-	
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	Von goossens et&#160;al.
 	, 
@@ -493,9 +481,112 @@
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
+	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000040" value="38">
+            <p><code class="verbatim">\Citep*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	
+	Von goossens, rahtz, and mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000041" value="39">
+            <p><code class="verbatim">\Citealt{goossens:companion}</code> — <span class="cite">
+	Von goossens et&#160;al.
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000042" value="40">
+            <p><code class="verbatim">\Citealt*{goossens:companion}</code> — <span class="cite">
+	Von goossens, rahtz, and mittelbach
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000043" value="41">
+            <p><code class="verbatim">\Citealt{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	Von goossens et&#160;al.
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000044" value="42">
+            <p><code class="verbatim">\Citealt*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	Von goossens, rahtz, and mittelbach
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000045" value="43">
+            <p><code class="verbatim">\Citealp{hagen:metafun}</code> — <span class="cite">
+	
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000046" value="44">
+            <p><code class="verbatim">\Citealp*{hagen:metafun}</code> — <span class="cite">
+	
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000047" value="45">
+            <p><code class="verbatim">\Citealp{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	
+	Von goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	
+</span> </p>
+
+        </li>
+        <li id="a0000000048" value="46">
+            <p><code class="verbatim">\Citealp*{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	Von goossens, rahtz, and mittelbach
 	, 
@@ -506,35 +597,46 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000049" value="47">
+            <p><code class="verbatim">\Citeauthor{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor*{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000050" value="48">
+            <p><code class="verbatim">\Citeauthor*{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000051" value="49">
+            <p><code class="verbatim">\Citeauthor{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Von goossens et&#160;al.</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor*{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000052" value="50">
+            <p><code class="verbatim">\Citeauthor*{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Von goossens, rahtz, and mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	
 </span> </p>
-</li>
-</ol>
+
+        </li>
+    </ol>
+
 <p><b class="bfseries">Postnote only</b> </p>
-<ol class="enumerate">
-  <li><p><code class="verbatim">\cite[page 99ff]{goossens:companion}</code> — <span class="cite">
+    <ol id="a0000000053" class="enumerate">
+        <li id="a0000000054" value="1">
+            <p><code class="verbatim">\cite[page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	
 	von Goossens et&#160;al.
@@ -543,8 +645,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite*[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000055" value="2">
+            <p><code class="verbatim">\cite*[page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	
 	von Goossens, Rahtz, and Mittelbach
@@ -553,110 +657,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	
-	von Goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\cite*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	
-	von Goossens, Rahtz, and Mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet[page 99ff]{goossens:companion}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet*[page 99ff]{goossens:companion}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	]
-	, 
-	Hagen
-	 
-	[
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	[
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	]
-	, 
-	Hagen
-	 
-	[
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep[page 99ff]{goossens:companion}</code> — <span class="cite">
-	[
-	
-	von Goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep*[page 99ff]{goossens:companion}</code> — <span class="cite">
-	[
-	
-	von Goossens, Rahtz, and Mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000056" value="3">
+            <p><code class="verbatim">\cite[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	
 	von Goossens et&#160;al.
@@ -669,8 +673,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citep*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000057" value="4">
+            <p><code class="verbatim">\cite*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	
 	von Goossens, Rahtz, and Mittelbach
@@ -683,24 +689,148 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000058" value="5">
+            <p><code class="verbatim">\citet[page 99ff]{goossens:companion}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000059" value="6">
+            <p><code class="verbatim">\citet*[page 99ff]{goossens:companion}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000060" value="7">
+            <p><code class="verbatim">\citet[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	]
+	, 
+	Hagen
+	 
+	[
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000061" value="8">
+            <p><code class="verbatim">\citet*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	[
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	]
+	, 
+	Hagen
+	 
+	[
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000062" value="9">
+            <p><code class="verbatim">\citep[page 99ff]{goossens:companion}</code> — <span class="cite">
+	[
+	
+	von Goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000063" value="10">
+            <p><code class="verbatim">\citep*[page 99ff]{goossens:companion}</code> — <span class="cite">
+	[
+	
+	von Goossens, Rahtz, and Mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000064" value="11">
+            <p><code class="verbatim">\citep[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	
+	von Goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000065" value="12">
+            <p><code class="verbatim">\citep*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	
+	von Goossens, Rahtz, and Mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000066" value="13">
+            <p><code class="verbatim">\citealt[page 99ff]{goossens:companion}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt*[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000067" value="14">
+            <p><code class="verbatim">\citealt*[page 99ff]{goossens:companion}</code> — <span class="cite">
 	von Goossens, Rahtz, and Mittelbach
 	 
 	
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000068" value="15">
+            <p><code class="verbatim">\citealt[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	
@@ -712,8 +842,10 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000069" value="16">
+            <p><code class="verbatim">\citealt*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	von Goossens, Rahtz, and Mittelbach
 	 
 	
@@ -725,24 +857,30 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000070" value="17">
+            <p><code class="verbatim">\citealp[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	
 	Hagen
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp*[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000071" value="18">
+            <p><code class="verbatim">\citealp*[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	
 	Hagen
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000072" value="19">
+            <p><code class="verbatim">\citealp[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	von Goossens et&#160;al.
 	, 
@@ -753,8 +891,10 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000073" value="20">
+            <p><code class="verbatim">\citealp*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	von Goossens, Rahtz, and Mittelbach
 	, 
@@ -765,64 +905,84 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000074" value="21">
+            <p><code class="verbatim">\citeauthor[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor*[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000075" value="22">
+            <p><code class="verbatim">\citeauthor*[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citefullauthor[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000076" value="23">
+            <p><code class="verbatim">\citefullauthor[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000077" value="24">
+            <p><code class="verbatim">\citeauthor[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens et&#160;al.</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000078" value="25">
+            <p><code class="verbatim">\citeauthor*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens, Rahtz, and Mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citefullauthor[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000079" value="26">
+            <p><code class="verbatim">\citefullauthor[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens, Rahtz, and Mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyear[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000080" value="27">
+            <p><code class="verbatim">\citeyear[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyear[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000081" value="28">
+            <p><code class="verbatim">\citeyear[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyearpar[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000082" value="29">
+            <p><code class="verbatim">\citeyearpar[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	[
 	
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyearpar[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000083" value="30">
+            <p><code class="verbatim">\citeyearpar[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	
 	<a href="natbib.html#goossens:companion" >1997</a>
@@ -831,8 +991,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000084" value="31">
+            <p><code class="verbatim">\Citet[page 99ff]{goossens:companion}</code> — <span class="cite">
 	Von goossens et&#160;al.
 	 
 	[
@@ -841,8 +1003,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet*[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000085" value="32">
+            <p><code class="verbatim">\Citet*[page 99ff]{goossens:companion}</code> — <span class="cite">
 	Von goossens, rahtz, and mittelbach
 	 
 	[
@@ -851,8 +1015,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000086" value="33">
+            <p><code class="verbatim">\Citet[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	Von goossens et&#160;al.
 	 
 	[
@@ -868,8 +1034,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000087" value="34">
+            <p><code class="verbatim">\Citet*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	Von goossens, rahtz, and mittelbach
 	 
 	[
@@ -885,8 +1053,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000088" value="35">
+            <p><code class="verbatim">\Citep[page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	
 	Von goossens et&#160;al.
@@ -895,8 +1065,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep*[page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000089" value="36">
+            <p><code class="verbatim">\Citep*[page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	
 	Von goossens, rahtz, and mittelbach
@@ -905,94 +1077,11 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000090" value="37">
+            <p><code class="verbatim">\Citep[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
-	
-	Von goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	
-	Von goossens, rahtz, and mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt[page 99ff]{goossens:companion}</code> — <span class="cite">
-	Von goossens et&#160;al.
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt*[page 99ff]{goossens:companion}</code> — <span class="cite">
-	Von goossens, rahtz, and mittelbach
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	Von goossens et&#160;al.
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	Von goossens, rahtz, and mittelbach
-	 
-	
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp[page 99ff]{hagen:metafun}</code> — <span class="cite">
-	
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp*[page 99ff]{hagen:metafun}</code> — <span class="cite">
-	
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	Von goossens et&#160;al.
 	, 
@@ -1002,9 +1091,112 @@
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
+	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000091" value="38">
+            <p><code class="verbatim">\Citep*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	
+	Von goossens, rahtz, and mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000092" value="39">
+            <p><code class="verbatim">\Citealt[page 99ff]{goossens:companion}</code> — <span class="cite">
+	Von goossens et&#160;al.
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000093" value="40">
+            <p><code class="verbatim">\Citealt*[page 99ff]{goossens:companion}</code> — <span class="cite">
+	Von goossens, rahtz, and mittelbach
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000094" value="41">
+            <p><code class="verbatim">\Citealt[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	Von goossens et&#160;al.
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000095" value="42">
+            <p><code class="verbatim">\Citealt*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	Von goossens, rahtz, and mittelbach
+	 
+	
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000096" value="43">
+            <p><code class="verbatim">\Citealp[page 99ff]{hagen:metafun}</code> — <span class="cite">
+	
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000097" value="44">
+            <p><code class="verbatim">\Citealp*[page 99ff]{hagen:metafun}</code> — <span class="cite">
+	
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000098" value="45">
+            <p><code class="verbatim">\Citealp[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	
+	Von goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000099" value="46">
+            <p><code class="verbatim">\Citealp*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	
 	Von goossens, rahtz, and mittelbach
 	, 
@@ -1015,35 +1207,46 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000100" value="47">
+            <p><code class="verbatim">\Citeauthor[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor*[page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000101" value="48">
+            <p><code class="verbatim">\Citeauthor*[page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000102" value="49">
+            <p><code class="verbatim">\Citeauthor[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Von goossens et&#160;al.</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000103" value="50">
+            <p><code class="verbatim">\Citeauthor*[page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Von goossens, rahtz, and mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-</ol>
+
+        </li>
+    </ol>
+
 <p><b class="bfseries">Both prenote and postnote</b> </p>
-<ol class="enumerate">
-  <li><p><code class="verbatim">\cite[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+    <ol id="a0000000104" class="enumerate">
+        <li id="a0000000105" value="1">
+            <p><code class="verbatim">\cite[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	see 
 	von Goossens et&#160;al.
@@ -1052,8 +1255,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000106" value="2">
+            <p><code class="verbatim">\cite*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	see 
 	von Goossens, Rahtz, and Mittelbach
@@ -1062,110 +1267,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\cite[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	see 
-	von Goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\cite*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	see 
-	von Goossens, Rahtz, and Mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet[see][page 99ff]{goossens:companion}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	[
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	[
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens et&#160;al.
-	 
-	[
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	]
-	, 
-	Hagen
-	 
-	[
-	see 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citet*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	von Goossens, Rahtz, and Mittelbach
-	 
-	[
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	]
-	, 
-	Hagen
-	 
-	[
-	see 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep[see][page 99ff]{goossens:companion}</code> — <span class="cite">
-	[
-	see 
-	von Goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
-	[
-	see 
-	von Goossens, Rahtz, and Mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\citep[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000107" value="3">
+            <p><code class="verbatim">\cite[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	see 
 	von Goossens et&#160;al.
@@ -1178,8 +1283,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citep*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000108" value="4">
+            <p><code class="verbatim">\cite*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	see 
 	von Goossens, Rahtz, and Mittelbach
@@ -1192,24 +1299,148 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000109" value="5">
+            <p><code class="verbatim">\citet[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	[
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000110" value="6">
+            <p><code class="verbatim">\citet*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	[
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000111" value="7">
+            <p><code class="verbatim">\citet[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens et&#160;al.
+	 
+	[
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	]
+	, 
+	Hagen
+	 
+	[
+	see 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000112" value="8">
+            <p><code class="verbatim">\citet*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	von Goossens, Rahtz, and Mittelbach
+	 
+	[
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	]
+	, 
+	Hagen
+	 
+	[
+	see 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000113" value="9">
+            <p><code class="verbatim">\citep[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+	[
+	see 
+	von Goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000114" value="10">
+            <p><code class="verbatim">\citep*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+	[
+	see 
+	von Goossens, Rahtz, and Mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000115" value="11">
+            <p><code class="verbatim">\citep[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	see 
+	von Goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000116" value="12">
+            <p><code class="verbatim">\citep*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	see 
+	von Goossens, Rahtz, and Mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000117" value="13">
+            <p><code class="verbatim">\citealt[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	see 
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000118" value="14">
+            <p><code class="verbatim">\citealt*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	von Goossens, Rahtz, and Mittelbach
 	 
 	see 
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000119" value="15">
+            <p><code class="verbatim">\citealt[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	von Goossens et&#160;al.
 	 
 	see 
@@ -1221,8 +1452,10 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealt*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000120" value="16">
+            <p><code class="verbatim">\citealt*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	von Goossens, Rahtz, and Mittelbach
 	 
 	see 
@@ -1234,24 +1467,30 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000121" value="17">
+            <p><code class="verbatim">\citealp[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	see 
 	Hagen
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000122" value="18">
+            <p><code class="verbatim">\citealp*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	see 
 	Hagen
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000123" value="19">
+            <p><code class="verbatim">\citealp[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	see 
 	von Goossens et&#160;al.
 	, 
@@ -1262,8 +1501,10 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citealp*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000124" value="20">
+            <p><code class="verbatim">\citealp*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	see 
 	von Goossens, Rahtz, and Mittelbach
 	, 
@@ -1274,64 +1515,84 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000125" value="21">
+            <p><code class="verbatim">\citeauthor[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000126" value="22">
+            <p><code class="verbatim">\citeauthor*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citefullauthor[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000127" value="23">
+            <p><code class="verbatim">\citefullauthor[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000128" value="24">
+            <p><code class="verbatim">\citeauthor[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens et&#160;al.</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeauthor*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000129" value="25">
+            <p><code class="verbatim">\citeauthor*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens, Rahtz, and Mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citefullauthor[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000130" value="26">
+            <p><code class="verbatim">\citefullauthor[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >von Goossens, Rahtz, and Mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyear[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000131" value="27">
+            <p><code class="verbatim">\citeyear[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyear[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000132" value="28">
+            <p><code class="verbatim">\citeyear[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >1997</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyearpar[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000133" value="29">
+            <p><code class="verbatim">\citeyearpar[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	[
 	see 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citeyearpar[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000134" value="30">
+            <p><code class="verbatim">\citeyearpar[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
 	see 
 	<a href="natbib.html#goossens:companion" >1997</a>
@@ -1340,8 +1601,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000135" value="31">
+            <p><code class="verbatim">\Citet[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	Von goossens et&#160;al.
 	 
 	[
@@ -1350,8 +1613,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000136" value="32">
+            <p><code class="verbatim">\Citet*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	Von goossens, rahtz, and mittelbach
 	 
 	[
@@ -1360,8 +1625,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000137" value="33">
+            <p><code class="verbatim">\Citet[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	Von goossens et&#160;al.
 	 
 	[
@@ -1377,8 +1644,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citet*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000138" value="34">
+            <p><code class="verbatim">\Citet*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	Von goossens, rahtz, and mittelbach
 	 
 	[
@@ -1394,8 +1663,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000139" value="35">
+            <p><code class="verbatim">\Citep[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	see 
 	Von goossens et&#160;al.
@@ -1404,8 +1675,10 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000140" value="36">
+            <p><code class="verbatim">\Citep*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
 	[
 	see 
 	Von goossens, rahtz, and mittelbach
@@ -1414,94 +1687,11 @@
 	, page 99ff
 	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000141" value="37">
+            <p><code class="verbatim">\Citep[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	[
-	see 
-	Von goossens et&#160;al.
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citep*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	[
-	see 
-	Von goossens, rahtz, and mittelbach
-	, 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-	]
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt[see][page 99ff]{goossens:companion}</code> — <span class="cite">
-	Von goossens et&#160;al.
-	 
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
-	Von goossens, rahtz, and mittelbach
-	 
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	Von goossens et&#160;al.
-	 
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	see 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealt*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
-	Von goossens, rahtz, and mittelbach
-	 
-	see 
-	<a href="natbib.html#goossens:companion" >1997</a>
-	, 
-	Hagen
-	 
-	see 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
-	see 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
-	see 
-	Hagen
-	, 
-	<a href="natbib.html#hagen:metafun" >2000</a>
-	, page 99ff
-</span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	see 
 	Von goossens et&#160;al.
 	, 
@@ -1511,9 +1701,112 @@
 	, 
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
+	]
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citealp*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000142" value="38">
+            <p><code class="verbatim">\Citep*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	[
+	see 
+	Von goossens, rahtz, and mittelbach
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+	]
+</span> </p>
+
+        </li>
+        <li id="a0000000143" value="39">
+            <p><code class="verbatim">\Citealt[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+	Von goossens et&#160;al.
+	 
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000144" value="40">
+            <p><code class="verbatim">\Citealt*[see][page 99ff]{goossens:companion}</code> — <span class="cite">
+	Von goossens, rahtz, and mittelbach
+	 
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000145" value="41">
+            <p><code class="verbatim">\Citealt[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	Von goossens et&#160;al.
+	 
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	see 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000146" value="42">
+            <p><code class="verbatim">\Citealt*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	Von goossens, rahtz, and mittelbach
+	 
+	see 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	 
+	see 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000147" value="43">
+            <p><code class="verbatim">\Citealp[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+	see 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000148" value="44">
+            <p><code class="verbatim">\Citealp*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+	see 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000149" value="45">
+            <p><code class="verbatim">\Citealp[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+	see 
+	Von goossens et&#160;al.
+	, 
+	<a href="natbib.html#goossens:companion" >1997</a>
+	, 
+	Hagen
+	, 
+	<a href="natbib.html#hagen:metafun" >2000</a>
+	, page 99ff
+</span> </p>
+
+        </li>
+        <li id="a0000000150" value="46">
+            <p><code class="verbatim">\Citealp*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	see 
 	Von goossens, rahtz, and mittelbach
 	, 
@@ -1524,50 +1817,67 @@
 	<a href="natbib.html#hagen:metafun" >2000</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000151" value="47">
+            <p><code class="verbatim">\Citeauthor[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000152" value="48">
+            <p><code class="verbatim">\Citeauthor*[see][page 99ff]{hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000153" value="49">
+            <p><code class="verbatim">\Citeauthor[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Von goossens et&#160;al.</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\Citeauthor*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000154" value="50">
+            <p><code class="verbatim">\Citeauthor*[see][page 99ff]{goossens:companion,hagen:metafun}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Von goossens, rahtz, and mittelbach</a>
 	, 
 	<a href="natbib.html#hagen:metafun" >Hagen</a>
 	, page 99ff
 </span> </p>
-</li>
-</ol>
+
+        </li>
+    </ol>
+
 <p><b class="bfseries">Miscellaneous Commands</b> </p>
-<ol class="enumerate">
-  <li><p><code class="verbatim">\citetext{plain text}</code> — [plain text] </p>
-</li>
-  <li><p><code class="verbatim">\defcitealias{goossens:companion}{Paper~I}\citetalies{plain text}</code> — <span class="cite">
+    <ol id="a0000000155" class="enumerate">
+        <li id="a0000000156" value="1">
+            <p><code class="verbatim">\citetext{plain text}</code> — [plain text] </p>
+
+        </li>
+        <li id="a0000000157" value="2">
+            <p><code class="verbatim">\defcitealias{goossens:companion}{Paper~I}\citetalies{plain text}</code> — <span class="cite">
 	<a href="natbib.html#goossens:companion" >Paper&#160;I</a>
 	
 </span> </p>
-</li>
-  <li><p><code class="verbatim">\citepalias{goossens:companion}</code> — <span class="cite">
+
+        </li>
+        <li id="a0000000158" value="3">
+            <p><code class="verbatim">\citepalias{goossens:companion}</code> — <span class="cite">
 	[
 	
 	<a href="natbib.html#goossens:companion" >Paper&#160;I</a>
 	
 	]
 </span> </p>
-</li>
-</ol>
+
+        </li>
+    </ol>
+
 <div class="bibliography">
 <h1>Bibliography</h1>
 <dl class="bibliography">

--- a/unittests/Packages/enumerate.py
+++ b/unittests/Packages/enumerate.py
@@ -69,9 +69,11 @@ def test_enumerate():
     assert enums[0].term(items[1].position) == '2.'
 
     items = enums[1].getElementsByTagName('item')
+    assert enums[1].listType == 'a)'
     assert enums[1].term(items[0].position) == 'a)'
     assert enums[1].term(items[1].position) == 'b)'
 
     items = enums[2].getElementsByTagName('item')
+    assert enums[2].listType == '<I>'
     assert enums[2].term(items[0].position) == '<I>'
     assert enums[2].term(items[11].position) == '<XII>'

--- a/unittests/Packages/enumerate.py
+++ b/unittests/Packages/enumerate.py
@@ -1,3 +1,32 @@
+from plasTeX.TeX import TeX
+
+def test_enumerate():
+    tex = TeX()
+    tex.input(r'''
+      \documentclass{article}
+      \begin{document}
+      \begin{enumerate}
+        \item First
+        \item Second
+      \end{enumerate}
+
+      \begin{enumerate}
+        ignore this
+        \item First
+        \vspace{1em} % also ignored
+        \item Second
+      \end{enumerate}
+
+      \end{document}
+      ''')
+
+    enums = tex.parse().getElementsByTagName('enumerate')
+
+    items = enums[0].getElementsByTagName('item')
+    assert len(items) == 2
+
+    items = enums[1].getElementsByTagName('item')
+    assert len(items) == 2
 import pytest
 from plasTeX.TeX import TeX
 

--- a/unittests/benchmarks/enumerate.html
+++ b/unittests/benchmarks/enumerate.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/benchmarks/enumerate.html
+++ b/unittests/benchmarks/enumerate.html
@@ -98,19 +98,19 @@
 
     <ol id="a0000000023" class="enumerate custom-terms">
         <li id="a0000000024" value="1">
-<div class="list-item-marker default-marker">a></div>            <div class="list-item-content">
+<div class="list-item-marker default-marker">a&gt;</div>            <div class="list-item-content">
                 <p>First </p>
 
             </div>
         </li>
         <li id="a0000000025" value="2">
-<div class="list-item-marker default-marker">b></div>            <div class="list-item-content">
+<div class="list-item-marker default-marker">b&gt;</div>            <div class="list-item-content">
                 <p>Second </p>
 
             </div>
         </li>
         <li id="a0000000026" value="3">
-<div class="list-item-marker default-marker">c></div>            <div class="list-item-content">
+<div class="list-item-marker default-marker">c&gt;</div>            <div class="list-item-content">
                 <p>Third </p>
 
             </div>

--- a/unittests/benchmarks/enumerate.html
+++ b/unittests/benchmarks/enumerate.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  MathJax = { 
+    tex: {
+		    inlineMath: [['\\(','\\)']]
+	} }
+</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+<meta name="generator" content="plasTeX" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+    <ol id="a0000000002" class="enumerate">
+        <li id="a0000000003" value="1">
+            <p>First </p>
+
+        </li>
+        <li id="a0000000004" value="2">
+            <p>Second </p>
+
+        </li>
+    </ol>
+
+    <ol id="a0000000005" class="enumerate">
+        <li id="a0000000006" value="1">
+            <p>First </p>
+
+        </li>
+        <li id="a0000000007" value="2">
+                <ol id="a0000000008" class="enumerate">
+        <li id="a0000000009" value="1">
+            <p>a </p>
+
+        </li>
+        <li id="a0000000010" value="2">
+            <p>b </p>
+
+        </li>
+        <li id="a0000000011" value="3">
+                <ol id="a0000000012" class="enumerate">
+        <li id="a0000000013" value="1">
+            <p>c </p>
+
+        </li>
+        <li id="a0000000014" value="2">
+            <p>d </p>
+
+        </li>
+        <li id="a0000000015" value="3">
+                <ol id="a0000000016" class="enumerate">
+        <li id="a0000000017" value="1">
+            <p>e </p>
+
+        </li>
+        <li id="a0000000018" value="2">
+            <p>f </p>
+
+        </li>
+    </ol>
+
+
+        </li>
+    </ol>
+
+
+        </li>
+    </ol>
+
+
+        </li>
+    </ol>
+
+    <ol id="a0000000019" class="enumerate custom-terms">
+        <li id="a0000000020" value="1">
+<div class="list-item-marker default-marker">1)</div>            <div class="list-item-content">
+                <p>First </p>
+
+            </div>
+        </li>
+        <li id="a0000000021" value="2">
+<div class="list-item-marker default-marker">2)</div>            <div class="list-item-content">
+                <p>Second </p>
+
+            </div>
+        </li>
+        <li id="a0000000022" value="3">
+<div class="list-item-marker default-marker">3)</div>            <div class="list-item-content">
+                <p>Third </p>
+
+            </div>
+        </li>
+    </ol>
+
+    <ol id="a0000000023" class="enumerate custom-terms">
+        <li id="a0000000024" value="1">
+<div class="list-item-marker default-marker">a></div>            <div class="list-item-content">
+                <p>First </p>
+
+            </div>
+        </li>
+        <li id="a0000000025" value="2">
+<div class="list-item-marker default-marker">b></div>            <div class="list-item-content">
+                <p>Second </p>
+
+            </div>
+        </li>
+        <li id="a0000000026" value="3">
+<div class="list-item-marker default-marker">c></div>            <div class="list-item-content">
+                <p>Third </p>
+
+            </div>
+        </li>
+    </ol>
+
+    <ol id="a0000000027" class="enumerate custom-terms">
+        <li id="a0000000028" value="1">
+<div class="list-item-marker default-marker">I)</div>            <div class="list-item-content">
+                <p>First </p>
+
+            </div>
+        </li>
+        <li id="a0000000029" value="2">
+<div class="list-item-marker default-marker">II)</div>            <div class="list-item-content">
+                <p>Second </p>
+
+            </div>
+        </li>
+        <li id="a0000000030" value="3">
+<div class="list-item-marker default-marker">III)</div>            <div class="list-item-content">
+                <p>Third </p>
+
+            </div>
+        </li>
+    </ol>
+
+
+</body>
+</html>

--- a/unittests/enumerate.py
+++ b/unittests/enumerate.py
@@ -1,0 +1,48 @@
+import pytest
+from plasTeX.TeX import TeX
+
+def test_enumerate():
+    tex = TeX()
+    tex.input(r'''
+      \documentclass{article}
+      \begin{document}
+      \begin{enumerate}
+        \item First
+        \item Second
+      \end{enumerate}
+
+      \begin{enumerate}[a)]
+        \item First
+        \item Second
+      \end{enumerate}
+
+      \begin{enumerate}[<I>]
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+        \item a
+      \end{enumerate}
+      \end{document}
+      ''')
+    enums = tex.parse().getElementsByTagName('enumerate')
+    items = enums[0].getElementsByTagName('item')
+    assert len(items) == 2
+    assert items[0].position == 1
+    assert enums[0].term(items[0].position) == '1.'
+    assert enums[0].term(items[1].position) == '2.'
+
+    items = enums[1].getElementsByTagName('item')
+    assert enums[1].term(items[0].position) == 'a)'
+    assert enums[1].term(items[1].position) == 'b)'
+
+    items = enums[2].getElementsByTagName('item')
+    assert enums[2].term(items[0].position) == '<I>'
+    assert enums[2].term(items[11].position) == '<XII>'

--- a/unittests/sources/enumerate.tex
+++ b/unittests/sources/enumerate.tex
@@ -1,0 +1,48 @@
+\documentclass{article}
+
+\begin{document}
+
+\begin{enumerate}
+\item First
+\item Second
+\end{enumerate}
+
+\begin{enumerate}
+\item First
+\item
+    \begin{enumerate}
+    \item a
+    \item b
+    \item
+        \begin{enumerate}
+        \item c
+        \item d
+        \item
+            \begin{enumerate}
+            \item e
+            \item f
+            \end{enumerate}
+        \end{enumerate}
+    \end{enumerate}
+\end{enumerate}
+
+\begin{enumerate}[1)]
+\item First
+\item Second
+\item Third
+\end{enumerate}
+
+\begin{enumerate}[a>]
+\item First
+\item Second
+\item Third
+\end{enumerate}
+
+\begin{enumerate}[I)]
+\item First
+\item Second
+\item Third
+\end{enumerate}
+
+
+\end{document}


### PR DESCRIPTION
(This builds on the changes added in #367)

This adds support for custom item labels to enumerate environments, following the format used by the enumerate LaTeX package.
    
The enumerate environment takes a single option argument specifying the format for item labels. The format string can contain any characters; the special characters I, i, A, a and 1 are replaced with corresponding encodings of the item's position in the list.

We tried a few different ways of rendering custom labels in HTML:

* `symbols()` in CSS: Chrome doesn't support this for anonymous list counters
* `@counter-style` rules: produced very complicated HTML for standard lists, and there are some compatibility issues

A decision has to be made about whether custom labels should be selectable: default list labels in HTML aren't selectable, but you could make a case that custom labels are part of the text and should be selectable. Certainly, we saw some cases where authors used custom labels for text that you'd expect to be included when you copy the list to the clipboard.

Finally, we just made separate container elements for the item's label and content, and used CSS subgrid display to lay them out. `display: subgrid` is very new, so you might consider this too adventurous. I haven't included our CSS in this branch, so this shouldn't be merged until there's agreement on how these should be displayed.

The HTML5 templates now also include `id` attributes and set the `value` attribute for list items, to make them linkable and to help assistive tech. The benchmark unit tests for a few things that use `enumerate` have had to be updated, as a consequence.