### PR TITLE
implement \slash

### DIFF
--- a/plasTeX/Base/TeX/Text.py
+++ b/plasTeX/Base/TeX/Text.py
@@ -142,7 +142,7 @@ class ControlSpace(Command):
     macroName = 'active::~'
 
 class slash(Command):
-    pass
+    str = '/'
 
 class filbreak(Command):
     pass

--- a/unittests/slash.py
+++ b/unittests/slash.py
@@ -1,0 +1,12 @@
+from plasTeX.TeX import TeX
+
+def test_slash():
+    tex = TeX()
+    tex.input(r'''
+        \documentclass{article}
+        \begin{document}A \slash B\end{document}
+    ''')
+
+    output = tex.parse()
+
+    assert output.getElementsByTagName('document')[0].textContent == 'A /B'


### PR DESCRIPTION
The `\slash` command outputs a forward slash.

This sets the `str` property on plasTeX's slash command, so that it is rendered as `/` when used in text mode.

Note that `\slash` absorbs any whitespace following it, so `A \slash B` will be rendered in HTML as `A /B`. This matches the pdflatex output.