### PR TITLE
implement \rightline

### DIFF
--- a/plasTeX/Base/TeX/Text.py
+++ b/plasTeX/Base/TeX/Text.py
@@ -180,6 +180,9 @@ class llap(Command):
 class centerline(Command):
     args = 'self'
 
+class rightline(Command):
+    args = 'self'
+
 class underbar(Command):
     args = 'self'
 

--- a/plasTeX/Renderers/HTML5/Alignment.jinja2s
+++ b/plasTeX/Renderers/HTML5/Alignment.jinja2s
@@ -4,7 +4,7 @@ name: center centering centerline
 name: flushleft raggedright leftline
 <div class="flushleft">{{ obj }}</div>
 
-name: raggedleft flushright llap
+name: raggedleft flushright llap rightline
 <div class="flushright">{{ obj }}</div>
 
 name: raggedbottom

--- a/unittests/benchmarks/Alignment.html
+++ b/unittests/benchmarks/Alignment.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  MathJax = { 
+    tex: {
+		    inlineMath: [['\\(','\\)']]
+	} }
+</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+<meta name="generator" content="plasTeX" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+<p>Normal alignment. </p>
+<p><div class="flushright">Right-aligned.</div> </p>
+<p><div class="flushleft">Left-aligned.</div> </p>
+
+</body>
+</html>

--- a/unittests/sources/Alignment.tex
+++ b/unittests/sources/Alignment.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\begin{document}
+
+Normal alignment.
+
+\rightline{Right-aligned.}
+
+\leftline{Left-aligned.}
+
+\end{document}


### PR DESCRIPTION
The \rightline command causes its contents to be aligned to the right.

For HTML5 output, this is equivalent to \raggedleft or \flushright.