### PR TITLE
Allow defining new environments whose contents are wrapped in a verbatim-like environment

### DIFF
--- a/plasTeX/Base/LaTeX/Verbatim.py
+++ b/plasTeX/Base/LaTeX/Verbatim.py
@@ -3,7 +3,7 @@ C.6.4 Verbatim
 
 """
 
-from plasTeX import VerbatimEnvironment, Command, sourceArguments, sourceChildren
+from plasTeX import Environment, VerbatimEnvironment, Command, sourceArguments, sourceChildren
 from plasTeX.Base.TeX.Text import bgroup
 from plasTeX.Tokenizer import Other
 

--- a/unittests/benchmarks/Verbatim.html
+++ b/unittests/benchmarks/Verbatim.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  MathJax = { 
+    tex: {
+		    inlineMath: [['\\(','\\)']]
+	} }
+</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+<meta name="generator" content="plasTeX" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+ Question <pre class="verbatim">Answer</pre> 
+</body>
+</html><!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  MathJax = { 
+    tex: {
+		    inlineMath: [['\\(','\\)']],
+	} }
+</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+<meta name="generator" content="plasTeX" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+ Question <pre class="verbatim">Answer</pre> 
+</body>
+</html>

--- a/unittests/sources/Verbatim.tex
+++ b/unittests/sources/Verbatim.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+
+\usepackage{verbatim}
+
+\newenvironment{answer}{\verbatim}{\endverbatim}
+
+\begin{document}
+    Question \begin{answer}Answer\end{answer}
+\end{document}


### PR DESCRIPTION
This changes plasTeX.VerbatimEnvironment to notice when a verbatim environment is opened in the beginning part of a new environment, and closed in the ending part.

When such an environment is used, it looks for the corresponding \end{...} command, expands it, and checks that the underlying verbatim environment is closed inside it.