### PR TITLE
add the bbm package

### DIFF
--- a/plasTeX/Packages/bbm.py
+++ b/plasTeX/Packages/bbm.py
@@ -1,0 +1,8 @@
+from plasTeX import Command, sourceArguments
+
+class mathbbm(Command):
+    args = 'self'
+
+    @property
+    def source(self):
+        return r'\mathbb{obj}'.format(obj=sourceArguments(self).strip())

--- a/plasTeX/Packages/bbm.py
+++ b/plasTeX/Packages/bbm.py
@@ -1,3 +1,9 @@
+"""
+The bbm package (https://ctan.org/pkg/bbm) provides a "blackboard bold" font, and a ``\mathbbm`` command to use that font.
+
+In this implementation, ``\mathbbm`` is rewritten to ``\mathbb``.
+"""
+
 from plasTeX import Command, sourceArguments
 
 class mathbbm(Command):

--- a/unittests/Packages/bbm.py
+++ b/unittests/Packages/bbm.py
@@ -1,0 +1,13 @@
+from plasTeX.TeX import TeX
+
+def test_bbm():
+    t = TeX()
+    t.input(r'''
+\documentclass{article}
+\usepackage{bbm}
+\begin{document}
+    $ \mathbbm{1} $
+\end{document}
+''')
+    p = t.parse()
+    assert p.getElementsByTagName('math')[0].source == r'$ \mathbb{1} $'


### PR DESCRIPTION
The bbm package provides a "blackboard bold" font, and a `\mathbbm` command to use that font.

MathJax supports these characters in the `\mathbb` command, so `\mathbbm` is rewritten to `\mathbb`, to be handled by MathJax.