### PR TITLE
cope with # as a delimiter for \verb

### DIFF
--- a/unittests/Verbatim.py
+++ b/unittests/Verbatim.py
@@ -25,6 +25,16 @@ class Verbatim(TestCase):
         text = ''.join(output.childNodes[1].childNodes)
         assert intext == text, '"%s" != "%s"' % (intext, text)
 
+    def testVerbHash(self):
+        intext = r' verbatim \tt text '
+        input = r'hi \verb#%s# bye' % intext
+        s = TeX()
+        s.input(input)
+        output = s.parse()
+        output.normalize()
+        text = ''.join(output.childNodes[1].childNodes)
+        assert intext == text, '"%s" != "%s"' % (intext, text)
+
     def testVerbStar(self):
         intext = r' verbatim \tt text '
         input = r'hi \verb*+%s+ bye' % intext


### PR DESCRIPTION
The character # is parsed as a `plasTeX.Tokenizer.Parameter` object when it immediately follows `\verb`, but is parsed as a `plasTeX.Tokenizer.Other` object otherwise.

This breaks the logic for the `\verb` command, which checks tokens to see if they're equal to the token given as the delimiter.

This commit adds a special case for `Parameter` objects as the end pattern, and changes it to an `Other` object.

There's a unit test verifying that `\verb#...#` works as it should.