### PR TITLE
strip trailing whitespace from the command name in \[re]newcommand

### DIFF
--- a/plasTeX/Base/LaTeX/Definitions.py
+++ b/plasTeX/Base/LaTeX/Definitions.py
@@ -23,6 +23,12 @@ class newcommand(Command):
         deflog.debug('command %s %s %s', *args)
         self.ownerDocument.context.newcommand(*args, **kwargs)
 
+    def filterArgumentSource(self, source, i):
+        if i==1:
+            source = source.replace(' ','')
+
+        return super().filterArgumentSource(source, i)
+
 class renewcommand(newcommand):
     pass
 

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -476,12 +476,12 @@ class Macro(Element):
         self.argSource = ''
         arg = None
         try:
-            for arg in self.arguments:
+            for i, arg in enumerate(self.arguments):
                 self.preArgument(arg, tex)
                 output, source = tex.readArgumentAndSource(parentNode=self,
                                                            name=arg.name,
                                                            **arg.options)
-                self.argSource += source
+                self.argSource += self.filterArgumentSource(source,i)
                 self.attributes[arg.name] = output
                 self.postArgument(arg, output, tex)
         except:
@@ -520,6 +520,17 @@ class Macro(Element):
         # the following arguments may contain labels.
         if arg.index == 0 and arg.name != '*modifier*':
             self.refstepcounter(tex)
+
+    def filterArgumentSource(self, source, i):
+        """
+        Apply some processing to the source of an argument.
+
+        Arguments:
+        source -- The unmodified source string of the argument.
+        i -- the index of the argument in the list of arguments.
+
+        """
+        return source
 
     def postArgument(self, arg, value, tex):
         """

--- a/unittests/Source.py
+++ b/unittests/Source.py
@@ -99,7 +99,12 @@ class Source(TestCase):
         source = normalize(output.source)
         assert input == source, '"%s" != "%s"' % (input, source)
         
-    
+    def testRenewcommand(self):
+        input = r'\renewcommand{\t}{test}\renewcommand\u{more}'
+        s = TeX()
+        s.input(input)
+        output = s.parse()
+        assert output.source == input
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/imagers/imagers.py
+++ b/unittests/imagers/imagers.py
@@ -54,6 +54,7 @@ def test_imager(imager_tuple, tmpdir):
     there.}
     \begin{document}
     $a + b = x$
+    $\>$
     \end{document}
     ''')
 

--- a/unittests/imagers/renewcommand.py
+++ b/unittests/imagers/renewcommand.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+
+from plasTeX.Renderers import Renderer
+from plasTeX.TeX import TeX
+
+def test_renewcommand_with_imager(tmpdir):
+    imager, ext, compiler = ('pdf2svg', '.svg', None)
+    kind = "vector-imager"
+
+    tmpdir = Path(str(tmpdir)) # for old pythons
+
+    tex = TeX()
+    tex.ownerDocument.config['images'][kind] = imager
+    if compiler is not None:
+        tex.ownerDocument.config['images'][kind.replace("imager", "compiler")] = compiler
+
+    tex.input(r'''
+    \documentclass{article}
+    \renewcommand{\>}{\rangle}
+    \begin{document}
+    $a + b = x$
+    $\>$
+    \end{document}
+    ''')
+
+    renderer = Renderer()
+    renderer['math'] = lambda node: node.vectorImage.url
+
+    directory = os.getcwd()
+    os.chdir(str(tmpdir))
+    renderer.render(tex.parse())
+    os.chdir(directory)
+
+    outfile = tmpdir/'images'/('img-0001' + ext)
+    root = Path(__file__).parent
+
+    assert outfile.exists(), "No image was created."
+


### PR DESCRIPTION
By default, plasTeX adds a space character to the end of the source of any element that doesn't have any arguments, to ensure that it's separated from the next token.

Most of the time this is safe because LaTeX usually ignores extra whitespace. But the `\renewcommand` command is sensitive to extra whitespace in the name of command being defined, when it's not a letter character, e.g. `\renewcommand{\> }` is not interpreted the same as `\renewcommand{\>}`.

I think that all of the `.source` methods on elements assume that they don't need to know their outer context, so it was hard to think of a good way of fixing this.

This commit adds a method `filterArgumentSource` to `Macro`, which is called on the source of each argument as it's processed.

The `\newcommand` macro and all the others that inherit from it use this to remove any whitespace from the inside of the first argument.